### PR TITLE
refactor(prisma): rename models  to singular, keep map plural

### DIFF
--- a/prisma/migrations/20260503235121_rename_inventory_to_inventories/migration.sql
+++ b/prisma/migrations/20260503235121_rename_inventory_to_inventories/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - You are about to drop the `inventory` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "inventory" DROP CONSTRAINT "inventory_business_unit_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "inventory" DROP CONSTRAINT "inventory_product_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "inventory_transactions" DROP CONSTRAINT "inventory_transactions_inventory_id_fkey";
+
+-- DropTable
+DROP TABLE "inventory";
+
+-- CreateTable
+CREATE TABLE "inventories" (
+    "id" TEXT NOT NULL,
+    "business_unit_id" TEXT NOT NULL,
+    "product_id" TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "min_quantity" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "inventories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "inventories_business_unit_id_product_id_key" ON "inventories"("business_unit_id", "product_id");
+
+-- AddForeignKey
+ALTER TABLE "inventories" ADD CONSTRAINT "inventories_business_unit_id_fkey" FOREIGN KEY ("business_unit_id") REFERENCES "business_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "inventories" ADD CONSTRAINT "inventories_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "inventory_transactions" ADD CONSTRAINT "inventory_transactions_inventory_id_fkey" FOREIGN KEY ("inventory_id") REFERENCES "inventories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ enum Role {
   ADMIN
 }
 
-model Users {
+model User {
   id             String  @id @default(uuid())
   businessUnitId String? @map("business_unit_id")
 
@@ -36,17 +36,17 @@ model Users {
   updatedById  String?  @map("updated_by")
   role         Role
 
-  businessUnit BusinessUnits? @relation(fields: [businessUnitId], references: [id])
-  updatedBy    Users?         @relation("UserUpdatedBy", fields: [updatedById], references: [id])
+  businessUnit BusinessUnit? @relation(fields: [businessUnitId], references: [id])
+  updatedBy    User?         @relation("UserUpdatedBy", fields: [updatedById], references: [id])
 
-  customerOrders        Orders[]                @relation("CustomerOrders")
-  attendantOrders       Orders[]                @relation("AttendantOrders")
-  inventoryTransactions InventoryTransactions[]
-  loyaltyAccounts       LoyaltyAccounts[]
+  customerOrders        Order[]                @relation("CustomerOrders")
+  attendantOrders       Order[]                @relation("AttendantOrders")
+  inventoryTransactions InventoryTransaction[]
+  loyaltyAccounts       LoyaltyAccount[]
 
-  userUpdatedBy            Users[]           @relation("UserUpdatedBy")
-  ordersUpdatedBy          Orders[]          @relation("OrdersUpdatedBy")
-  loyaltyAccountsUpdatedBy LoyaltyAccounts[] @relation("LoyaltyAccountsUpdatedBy")
+  userUpdatedBy            User[]           @relation("UserUpdatedBy")
+  ordersUpdatedBy          Order[]          @relation("OrdersUpdatedBy")
+  loyaltyAccountsUpdatedBy LoyaltyAccount[] @relation("LoyaltyAccountsUpdatedBy")
 
   @@index([role])
   @@index([businessUnitId])
@@ -57,7 +57,7 @@ model Users {
 // BUSINESS UNITS & MENU
 // ============================================================
 
-model BusinessUnits {
+model BusinessUnit {
   id        String   @id @default(uuid())
   name      String
   cnpj      String   @unique
@@ -68,26 +68,26 @@ model BusinessUnits {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  users      Users[]
-  orders     Orders[]
-  menuItems  BusinessUnitMenuItems[]
+  users      User[]
+  orders     Order[]
+  menuItems  BusinessUnitMenuItem[]
   inventory  Inventory[]
-  promotions Promotions[]
+  promotions Promotion[]
 
   @@map("business_units")
 }
 
-model Categories {
+model Category {
   id          String @id @default(uuid())
   name        String @unique
   description String
 
-  products Products[]
+  products Product[]
 
   @@map("categories")
 }
 
-model Products {
+model Product {
   id         String @id @default(uuid())
   categoryId String @map("category_id")
 
@@ -99,17 +99,17 @@ model Products {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  category   Categories              @relation(fields: [categoryId], references: [id])
-  menuItems  BusinessUnitMenuItems[]
+  category   Category               @relation(fields: [categoryId], references: [id])
+  menuItems  BusinessUnitMenuItem[]
   inventory  Inventory[]
-  orderItems OrderItems[]
+  orderItems OrderItem[]
 
   @@index([categoryId])
   @@index([isActive])
   @@map("products")
 }
 
-model BusinessUnitMenuItems {
+model BusinessUnitMenuItem {
   id             String @id @default(uuid())
   businessUnitId String @map("business_unit_id")
   productId      String @map("product_id")
@@ -119,8 +119,8 @@ model BusinessUnitMenuItems {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  businessUnit BusinessUnits @relation(fields: [businessUnitId], references: [id])
-  product      Products      @relation(fields: [productId], references: [id])
+  businessUnit BusinessUnit @relation(fields: [businessUnitId], references: [id])
+  product      Product      @relation(fields: [productId], references: [id])
 
   @@unique([businessUnitId, productId])
   @@map("business_unit_menu_items")
@@ -147,16 +147,16 @@ model Inventory {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  businessUnit BusinessUnits @relation(fields: [businessUnitId], references: [id])
-  product      Products      @relation(fields: [productId], references: [id])
+  businessUnit BusinessUnit @relation(fields: [businessUnitId], references: [id])
+  product      Product      @relation(fields: [productId], references: [id])
 
-  inventoryTransactions InventoryTransactions[]
+  inventoryTransactions InventoryTransaction[]
 
   @@unique([businessUnitId, productId])
-  @@map("inventory")
+  @@map("inventories")
 }
 
-model InventoryTransactions {
+model InventoryTransaction {
   id          String  @id @default(uuid())
   inventoryId String  @map("inventory_id")
   orderId     String? @map("order_id")
@@ -168,8 +168,8 @@ model InventoryTransactions {
   createdAt DateTime                 @default(now()) @map("created_at")
 
   inventory     Inventory @relation(fields: [inventoryId], references: [id])
-  order         Orders?   @relation(fields: [orderId], references: [id])
-  createdByUser Users     @relation(fields: [createdBy], references: [id])
+  order         Order?    @relation(fields: [orderId], references: [id])
+  createdByUser User      @relation(fields: [createdBy], references: [id])
 
   @@index([inventoryId])
   @@index([orderId])
@@ -199,7 +199,7 @@ enum OrderStatus {
   CANCELLED
 }
 
-model Orders {
+model Order {
   id             String  @id @default(uuid())
   businessUnitId String  @map("business_unit_id")
   customerId     String  @map("customer_id")
@@ -215,16 +215,16 @@ model Orders {
   updatedAt      DateTime     @updatedAt @map("updated_at")
   updatedById    String?      @map("updated_by")
 
-  businessUnit BusinessUnits @relation(fields: [businessUnitId], references: [id])
-  customer     Users         @relation("CustomerOrders", fields: [customerId], references: [id])
-  attendant    Users?        @relation("AttendantOrders", fields: [attendantId], references: [id])
-  updatedBy    Users?        @relation("OrdersUpdatedBy", fields: [updatedById], references: [id])
+  businessUnit BusinessUnit @relation(fields: [businessUnitId], references: [id])
+  customer     User         @relation("CustomerOrders", fields: [customerId], references: [id])
+  attendant    User?        @relation("AttendantOrders", fields: [attendantId], references: [id])
+  updatedBy    User?        @relation("OrdersUpdatedBy", fields: [updatedById], references: [id])
 
-  inventoryTransactions InventoryTransactions[]
-  orderItems            OrderItems[]
-  payments              Payments[]
-  orderPromotions       OrderPromotions[]
-  loyaltyTransactions   LoyaltyTransactions[]
+  inventoryTransactions InventoryTransaction[]
+  orderItems            OrderItem[]
+  payments              Payment[]
+  orderPromotions       OrderPromotion[]
+  loyaltyTransactions   LoyaltyTransaction[]
 
   @@index([customerId])
   @@index([businessUnitId])
@@ -234,7 +234,7 @@ model Orders {
   @@map("orders")
 }
 
-model OrderItems {
+model OrderItem {
   id        String @id @default(uuid())
   orderId   String @map("order_id")
   productId String @map("product_id")
@@ -244,8 +244,8 @@ model OrderItems {
   subtotal  Decimal @db.Decimal(10, 2)
   notes     String?
 
-  order   Orders   @relation(fields: [orderId], references: [id])
-  product Products @relation(fields: [productId], references: [id])
+  order   Order   @relation(fields: [orderId], references: [id])
+  product Product @relation(fields: [productId], references: [id])
 
   @@index([orderId])
   @@index([productId])
@@ -272,7 +272,7 @@ enum PaymentStatus {
   CANCELLED
 }
 
-model Payments {
+model Payment {
   id      String @id @default(uuid())
   orderId String @unique @map("order_id")
 
@@ -285,7 +285,7 @@ model Payments {
   createdAt        DateTime      @default(now()) @map("created_at")
   updatedAt        DateTime      @updatedAt @map("updated_at")
 
-  order Orders @relation(fields: [orderId], references: [id])
+  order Order @relation(fields: [orderId], references: [id])
 
   @@index([status])
   @@map("payments")
@@ -301,7 +301,7 @@ enum DiscountType {
   FREE_ITEM
 }
 
-model Promotions {
+model Promotion {
   id             String @id @default(uuid())
   businessUnitId String @map("business_unit_id")
 
@@ -315,24 +315,24 @@ model Promotions {
   createdAt     DateTime     @default(now()) @map("created_at")
   updatedAt     DateTime     @updatedAt @map("updated_at")
 
-  businessUnit BusinessUnits @relation(fields: [businessUnitId], references: [id])
+  businessUnit BusinessUnit @relation(fields: [businessUnitId], references: [id])
 
-  orderPromotions OrderPromotions[]
+  orderPromotions OrderPromotion[]
 
   @@index([businessUnitId])
   @@index([isActive, startDate, endDate])
   @@map("promotions")
 }
 
-model OrderPromotions {
+model OrderPromotion {
   id          String @id @default(uuid())
   orderId     String @map("order_id")
   promotionId String @map("promotion_id")
 
   discountApplied Decimal @map("discount_applied") @db.Decimal(10, 2)
 
-  order     Orders     @relation(fields: [orderId], references: [id])
-  promotion Promotions @relation(fields: [promotionId], references: [id])
+  order     Order     @relation(fields: [orderId], references: [id])
+  promotion Promotion @relation(fields: [promotionId], references: [id])
 
   @@map("order_promotions")
 }
@@ -348,7 +348,7 @@ enum LoyaltyTransactionType {
   ADJUSTMENT
 }
 
-model LoyaltyAccounts {
+model LoyaltyAccount {
   id         String @id @default(uuid())
   customerId String @unique @map("customer_id")
 
@@ -359,15 +359,15 @@ model LoyaltyAccounts {
   updatedAt    DateTime  @updatedAt @map("updated_at")
   updatedById  String?   @map("updated_by")
 
-  customer  Users  @relation(fields: [customerId], references: [id])
-  updatedBy Users? @relation("LoyaltyAccountsUpdatedBy", fields: [updatedById], references: [id])
+  customer  User  @relation(fields: [customerId], references: [id])
+  updatedBy User? @relation("LoyaltyAccountsUpdatedBy", fields: [updatedById], references: [id])
 
-  loyaltyTransactions LoyaltyTransactions[]
+  loyaltyTransactions LoyaltyTransaction[]
 
   @@map("loyalty_accounts")
 }
 
-model LoyaltyTransactions {
+model LoyaltyTransaction {
   id               String  @id @default(uuid())
   loyaltyAccountId String  @map("loyalty_account_id")
   orderId          String? @map("order_id")
@@ -377,8 +377,8 @@ model LoyaltyTransactions {
   description String
   createdAt   DateTime               @default(now()) @map("created_at")
 
-  loyaltyAccount LoyaltyAccounts @relation(fields: [loyaltyAccountId], references: [id])
-  order          Orders?         @relation(fields: [orderId], references: [id])
+  loyaltyAccount LoyaltyAccount @relation(fields: [loyaltyAccountId], references: [id])
+  order          Order?         @relation(fields: [orderId], references: [id])
 
   @@index([loyaltyAccountId])
   @@index([orderId])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,7 +8,7 @@ async function main(): Promise<void> {
   // =======================================================
   // BUSINESS UNITS
   // =======================================================
-  const unit1 = await prisma.businessUnits.upsert({
+  const unit1 = await prisma.businessUnit.upsert({
     where: { cnpj: '00.000.000/0001-00' },
     update: {},
     create: {
@@ -22,7 +22,7 @@ async function main(): Promise<void> {
     },
   });
 
-  const unit2 = await prisma.businessUnits.upsert({
+  const unit2 = await prisma.businessUnit.upsert({
     where: { cnpj: '00.000.000/0002-00' },
     update: {},
     create: {
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
   // =======================================================
   // USERS
   // =======================================================
-  await prisma.users.upsert({
+  await prisma.user.upsert({
     where: { email: 'r6-squad@raizes.com' },
     update: {},
     create: {
@@ -51,7 +51,7 @@ async function main(): Promise<void> {
     },
   });
 
-  await prisma.users.upsert({
+  await prisma.user.upsert({
     where: { email: 'admin-tribes@raizes.com' },
     update: {},
     create: {
@@ -64,7 +64,7 @@ async function main(): Promise<void> {
     },
   });
 
-  await prisma.users.upsert({
+  await prisma.user.upsert({
     where: { email: 'chief@raizes.com' },
     update: {},
     create: {
@@ -80,7 +80,7 @@ async function main(): Promise<void> {
   // =======================================================
   // CATEGORIES
   // =======================================================
-  const acaiCategory = await prisma.categories.upsert({
+  const acaiCategory = await prisma.category.upsert({
     where: { name: 'Açaí' },
     update: {},
     create: {
@@ -89,16 +89,17 @@ async function main(): Promise<void> {
     },
   });
 
-  const beverageCategory = await prisma.categories.upsert({
+  const beverageCategory = await prisma.category.upsert({
     where: { name: 'Beverage' },
     update: {},
     create: {
+      id: 'ab24d105-6abe-4cab-bf39-bffd8c8cdabd', // uuid static for api tests
       name: 'Beverage',
       description: 'Beverage Category',
     },
   });
 
-  const chickenCategory = await prisma.categories.upsert({
+  const chickenCategory = await prisma.category.upsert({
     where: { name: 'Chicken' },
     update: {},
     create: {
@@ -110,7 +111,7 @@ async function main(): Promise<void> {
   // =======================================================
   // PRODUCTS
   // =======================================================
-  const prod1 = await prisma.products.upsert({
+  const prod1 = await prisma.product.upsert({
     where: { name: 'Açaí Fitness' },
     update: {},
     create: {
@@ -122,7 +123,7 @@ async function main(): Promise<void> {
     },
   });
 
-  const prod2 = await prisma.products.upsert({
+  const prod2 = await prisma.product.upsert({
     where: { name: 'Lemon Juice' },
     update: {},
     create: {
@@ -133,7 +134,7 @@ async function main(): Promise<void> {
     },
   });
 
-  const prod3 = await prisma.products.upsert({
+  const prod3 = await prisma.product.upsert({
     where: { name: 'Grape Juice' },
     update: {},
     create: {
@@ -143,7 +144,7 @@ async function main(): Promise<void> {
       imageUrl: '@example3.com',
     },
   });
-  const prod4 = await prisma.products.upsert({
+  const prod4 = await prisma.product.upsert({
     where: { name: 'Chicken Stroganoff' },
     update: {},
     create: {
@@ -157,7 +158,7 @@ async function main(): Promise<void> {
   // =======================================================
   // BUSINESS UNIT MENU ITEMS
   // =======================================================
-  await prisma.businessUnitMenuItems.upsert({
+  await prisma.businessUnitMenuItem.upsert({
     where: { businessUnitId_productId: { businessUnitId: unit1.id, productId: prod1.id } },
     update: {},
     create: {
@@ -168,7 +169,7 @@ async function main(): Promise<void> {
     },
   });
 
-  await prisma.businessUnitMenuItems.upsert({
+  await prisma.businessUnitMenuItem.upsert({
     where: { businessUnitId_productId: { businessUnitId: unit1.id, productId: prod2.id } },
     update: {},
     create: {
@@ -179,7 +180,7 @@ async function main(): Promise<void> {
     },
   });
 
-  await prisma.businessUnitMenuItems.upsert({
+  await prisma.businessUnitMenuItem.upsert({
     where: { businessUnitId_productId: { businessUnitId: unit2.id, productId: prod2.id } },
     update: {},
     create: {
@@ -190,7 +191,7 @@ async function main(): Promise<void> {
     },
   });
 
-  await prisma.businessUnitMenuItems.upsert({
+  await prisma.businessUnitMenuItem.upsert({
     where: { businessUnitId_productId: { businessUnitId: unit2.id, productId: prod3.id } },
     update: {},
     create: {
@@ -200,7 +201,7 @@ async function main(): Promise<void> {
       isAvailable: true,
     },
   });
-  await prisma.businessUnitMenuItems.upsert({
+  await prisma.businessUnitMenuItem.upsert({
     where: { businessUnitId_productId: { businessUnitId: unit2.id, productId: prod4.id } },
     update: {},
     create: {

--- a/src/modules/business-units/infrastructure/persistence/prisma-product.repository.ts
+++ b/src/modules/business-units/infrastructure/persistence/prisma-product.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import type { Products as PrismaProduct, Prisma } from '@prisma/client';
+import type { Product as PrismaProduct, Prisma } from '@prisma/client';
 import Big from 'big.js';
 import {
   FindProductsByBusinessUnitInput,
@@ -15,14 +15,14 @@ export class PrismaProductRepository implements IProductRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async findById(id: string): Promise<Product | null> {
-    const raw = await this.prisma.products.findUnique({ where: { id } });
+    const raw = await this.prisma.product.findUnique({ where: { id } });
     return raw ? this.toEntity(raw) : null;
   }
 
   async findAllActive(input: FindProductsInput): Promise<Product[]> {
     const { pagination, filters } = input;
 
-    const raws = await this.prisma.products.findMany({
+    const raws = await this.prisma.product.findMany({
       where: {
         isActive: true,
         ...this.buildProductWhere(filters),
@@ -41,7 +41,7 @@ export class PrismaProductRepository implements IProductRepository {
   async findAllByBusinessUnit(input: FindProductsByBusinessUnitInput): Promise<Product[]> {
     const { businessUnitId, pagination, filters } = input;
 
-    const items = await this.prisma.businessUnitMenuItems.findMany({
+    const items = await this.prisma.businessUnitMenuItem.findMany({
       where: {
         businessUnitId,
         isAvailable: true,
@@ -76,11 +76,11 @@ export class PrismaProductRepository implements IProductRepository {
     });
   }
 
-  private buildProductWhere(filters?: ProductFilters): Prisma.ProductsWhereInput {
+  private buildProductWhere(filters?: ProductFilters): Prisma.ProductWhereInput {
     if (!filters) {
       return {};
     }
-    const where: Prisma.ProductsWhereInput = {};
+    const where: Prisma.ProductWhereInput = {};
     if (filters.search) {
       where.name = { contains: filters.search, mode: 'insensitive' };
     }


### PR DESCRIPTION
Aligns Prisma model names with the standard convention (singular PascalCase) while preserving plural snake_case table names via @@map. No DB schema change beyond renaming the inventory table to inventories for consistency.