### PR TITLE
feat(errors): global exception filter with typed error hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ browsing, order management, payment processing, inventory control and a
 customer loyalty program — across multiple business units (franchises).
 
 > **Status:** the project is being built incrementally. The product catalog
-> module is currently implemented; auth, orders, payments, inventory and
-> loyalty modules are planned (see [Roadmap](#roadmap)).
+> and identity modules are currently implemented (JWT login, global role
+> guard, argon2 hashing); orders, payments, inventory and loyalty modules
+> are planned (see [Roadmap](#roadmap)).
 
 ---
 
@@ -117,10 +118,16 @@ PostgreSQL. DTOs convert to `number` only at the HTTP edge.
 
 **6. Errors model intent, not transport**
 
-- `ProductsFetchException` (an application-layer error) wraps the underlying
-  cause using the standard `Error.cause` option.
-- `NotFoundException` (NestJS) is thrown when a resource is missing, so the
-  framework converts it to `404 Not Found` automatically.
+- Domain and application errors extend shared base classes
+  (`DomainError` / `ApplicationError`) that carry a transport-agnostic
+  `kind` (`not-found`, `invalid`, `conflict`, `unauthorized`, `forbidden`,
+  `unavailable`) — never an HTTP status.
+- A global exception filter (`shared/filter/`, registered via `APP_FILTER`)
+  is the single place that maps `kind` → HTTP status, re-wraps NestJS
+  `HttpException`s, and emits one consistent JSON envelope. It logs the full
+  `Error.cause` chain server-side but never leaks internals to the client.
+- `ProductsFetchError` (application layer) wraps the underlying repository
+  failure with the standard `Error.cause` option and `kind: unavailable`.
 
 **7. `shared/` is the cross-context kernel**
 Anything reused across two or more contexts (Prisma client lifecycle,
@@ -177,9 +184,11 @@ errors still fail the build.
 > surfaces only at runtime (DI injects `undefined`, validator silently
 > skipped, ORM loses the relation).
 >
-> **Does not currently affect this project** — Prisma does not rely on
-> `emitDecoratorMetadata`, domain entities are plain classes, and
-> `class-validator` is not yet wired. Watch for it when:
+> **Low risk for this project today** — Prisma does not rely on
+> `emitDecoratorMetadata` and domain entities are plain classes.
+> `class-validator` is now wired (global `ValidationPipe` + `SignInDto`),
+> but its DTOs are flat (no bidirectional aggregate references), so the
+> mis-emit cannot trigger yet. Watch for it when:
 >
 > - Adding `class-validator` DTOs with bidirectional aggregate references
 > - Adding modules with circular DI (use NestJS `forwardRef()`)
@@ -201,34 +210,42 @@ src/
 ├── main.ts                       ← Bootstrap: prefix /api, CORS, shutdown hooks
 ├── app.module.ts                 ← Root module wiring
 ├── shared/                       ← Cross-context kernel
+│   ├── auth/                     ← Global AuthGuard, @Public/@Roles, JWT payload
+│   ├── errors/                   ← DomainError/ApplicationError base + ErrorKind
+│   ├── filter/                   ← Global exception filter (error → envelope)
 │   ├── infrastructure/
 │   │   └── prisma/               ← @Global() PrismaService + lifecycle
 │   └── pagination/               ← Cursor-pagination types and DTO envelope
 └── modules/                      ← One folder per bounded context
-    └── business-units/           ← Products, Categories, Menu Items, Units
-        ├── business-units.module.ts
-        ├── domain/               ← Pure rules (no framework imports)
-        │   ├── entities/         ← Product, BusinessUnitMenuItem
-        │   └── repositories/     ← Interfaces + DI tokens
-        ├── application/          ← Orchestration
-        │   ├── use-cases/        ← One file per business action
-        │   └── errors/           ← Application-layer errors (e.g. fetch wrappers)
-        └── infrastructure/       ← Adapters
-            ├── persistence/      ← Prisma repository implementations
-            └── http/
-                ├── controllers/  ← NestJS controllers
-                └── dto/          ← Response DTOs (serialization only)
+    ├── business-units/           ← Products, Categories, Menu Items, Units
+    │   ├── business-units.module.ts
+    │   ├── domain/               ← Pure rules (no framework imports)
+    │   │   ├── entities/         ← Product, BusinessUnitMenuItem
+    │   │   └── repositories/     ← Interfaces + DI tokens
+    │   ├── application/          ← Orchestration
+    │   │   ├── use-cases/        ← One file per business action
+    │   │   └── errors/           ← App-layer errors (extend shared ApplicationError)
+    │   └── infrastructure/       ← Adapters
+    │       ├── persistence/      ← Prisma repository implementations
+    │       └── http/
+    │           ├── controllers/  ← NestJS controllers
+    │           └── dto/          ← Response DTOs (serialization only)
+    └── identity/                 ← Users, JWT auth, login, roles
+        ├── identity.module.ts
+        ├── domain/               ← User entity, repo + hasher/signer ports, UserRole
+        ├── application/          ← SignInUseCase + app-layer errors
+        └── infrastructure/       ← Argon2 hasher, JWT signer, auth controller/DTO
 prisma/
 ├── schema.prisma                 ← Single source of truth for the database
 ├── seed.ts                       ← Idempotent seed for local dev
 └── migrations/                   ← Versioned migration history
 test/
-└── app.e2e-spec.ts               ← End-to-end HTTP tests
+├── app.e2e-spec.ts               ← Product HTTP e2e
+└── global-error-filter.e2e-spec.ts ← Error envelope e2e (full pipeline)
 ```
 
-> Future contexts (`identity`, `inventory`, `orders`, `payments`,
-> `promotions`, `loyalty`) will follow the same internal shape under
-> `src/modules/`.
+> Remaining contexts (`inventory`, `orders`, `payments`, `promotions`,
+> `loyalty`) will follow the same internal shape under `src/modules/`.
 
 ---
 
@@ -379,6 +396,31 @@ npm run devs
 
 All routes are prefixed with **`/api`**.
 
+### Authentication
+
+A global `AuthGuard` protects every route by default; routes opt out with
+`@Public()`. **Every endpoint shipped so far is public.** Protected routes
+(none yet) will require a `Bearer` JWT in the `Authorization` header and may
+further restrict by role via `@Roles()`.
+
+| Method | Path              | Auth   | Description                                 |
+| ------ | ----------------- | ------ | ------------------------------------------- |
+| `POST` | `/api/auth/login` | Public | Exchange `username` + `password` for a JWT. |
+
+Request body — `SignInDto` (`password` ≥ 8 chars):
+
+```json
+{ "username": "jane", "password": "min-8-chars" }
+```
+
+Response — `200 OK`:
+
+```json
+{ "access_token": "eyJhbGciOiJI..." }
+```
+
+Invalid credentials return `401` (see [Error responses](#error-responses)).
+
 ### Products
 
 | Method | Path                                             | Description                                                                                                   |
@@ -404,10 +446,32 @@ All routes are prefixed with **`/api`**.
 
 ### Error responses
 
-| Status | When                                                     | Body shape                                                      |
-| ------ | -------------------------------------------------------- | --------------------------------------------------------------- |
-| `404`  | A product or business unit does not exist                | `{ "statusCode": 404, "message": "...", "error": "Not Found" }` |
-| `500`  | Repository / database failure (`ProductsFetchException`) | Standard NestJS error envelope                                  |
+Every error passes through the global exception filter and is returned with a
+**single consistent envelope**. Internal details (stack, `Error.cause` chain)
+are logged server-side but never sent to the client:
+
+```json
+{
+  "statusCode": 503,
+  "error": "Service Unavailable",
+  "message": "Could not retrieve active products.",
+  "path": "/api/products",
+  "timestamp": "2026-05-17T12:00:00.000Z"
+}
+```
+
+| Status | When                                                                   |
+| ------ | ---------------------------------------------------------------------- |
+| `400`  | Request body fails validation (`class-validator` + `ValidationPipe`)   |
+| `401`  | Invalid login credentials, or missing/invalid JWT on a protected route |
+| `404`  | Requested product / business unit does not exist                       |
+| `503`  | Repository / database failure (`ProductsFetchError`)                   |
+
+Application/domain errors carry a `kind` that the filter maps to a status:
+`not-found` → 404, `invalid` → 422, `conflict` → 409, `unauthorized` → 401,
+`forbidden` → 403, `unavailable` → 503. NestJS `HttpException`s (e.g.
+`NotFoundException`, validation `BadRequestException`) keep their own status
+and are re-wrapped into the same envelope.
 
 ---
 
@@ -429,13 +493,15 @@ npm run test:e2e
 
 ### Testing strategy
 
-- **Unit tests** mock the `IProductRepository` interface, so use cases are
-  validated without any database. Entities and DTOs are tested in isolation
-  for behavior (`isAvailable()`) and pure transformation (`fromEntity()`).
+- **Unit tests** substitute the repository interfaces (`IProductRepository`,
+  `IUserRepository`) with test doubles, so use cases and the `AuthGuard` are
+  validated without any database. Entities, DTOs and the global exception
+  filter are tested in isolation.
 - **e2e tests** boot the full Nest application against the development
-  database and exercise the HTTP surface.
+  database and exercise the HTTP surface, including the global error
+  envelope via a throwing repository (`global-error-filter.e2e-spec.ts`).
 - Each test asserts both **success paths** and **failure paths** — including
-  `NotFoundException` propagation and `ProductsFetchException` wrapping
+  `NotFoundException` propagation and `ProductsFetchError` wrapping
   with `Error.cause`.
 
 ---
@@ -457,11 +523,12 @@ npm run test:e2e
 
 ## Roadmap
 
-The product catalog module is shipped. Upcoming modules — already designed
-in the database schema — are:
+The product catalog and identity modules are shipped. Upcoming modules —
+already designed in the database schema — are:
 
-- [ ] **Auth** — JWT + role-based guards (`CUSTOMER`, `ATTENDANT`, `KITCHEN`,
-      `MANAGER`, `ADMIN`)
+- [x] **Auth** — JWT login, global role guard, argon2 hashing (`CUSTOMER`,
+      `ATTENDANT`, `KITCHEN`, `MANAGER`, `ADMIN`). Refresh-token rotation
+      and user registration still pending.
 - [ ] **Orders** — order creation, item management, status transitions
 - [ ] **Payments** — gateway integration (mocked initially), refund flow
 - [ ] **Inventory** — stock, reservations, audit log of inventory transactions

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,8 +3,9 @@ import { PrismaModule } from '@shared/infrastructure/prisma/prisma.module';
 import { BusinessUnitsModule } from '@modules/business-units/business-units.module';
 import { ConfigModule } from '@nestjs/config';
 import { IdentityModule } from '@modules/identity/identity.module';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { AuthGuard } from '@shared/auth/auth.guard';
+import { GlobalErrorFilter } from '@shared/filter/global-error.filter';
 
 @Module({
   imports: [
@@ -17,6 +18,10 @@ import { AuthGuard } from '@shared/auth/auth.guard';
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: GlobalErrorFilter,
     },
   ],
 })

--- a/src/modules/business-units/application/errors/product-fetch.error.ts
+++ b/src/modules/business-units/application/errors/product-fetch.error.ts
@@ -1,0 +1,8 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+export class ProductsFetchError extends ApplicationError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.UNAVAILABLE, message, options);
+  }
+}

--- a/src/modules/business-units/application/errors/product-fetch.exception.ts
+++ b/src/modules/business-units/application/errors/product-fetch.exception.ts
@@ -1,6 +1,0 @@
-export class ProductsFetchException extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.name = 'ProductsFetchException';
-  }
-}

--- a/src/modules/business-units/application/use-cases/get-active-products.use-case.spec.ts
+++ b/src/modules/business-units/application/use-cases/get-active-products.use-case.spec.ts
@@ -6,7 +6,7 @@ import {
   PRODUCT_REPOSITORY,
 } from '../../domain/repositories/product.repository';
 import { GetActiveProductsUseCase } from './get-active-products.use-case';
-import { ProductsFetchException } from '../errors/product-fetch.exception';
+import { ProductsFetchError } from '../errors/product-fetch.error';
 import { Product } from '../../domain/entities/product.entity';
 
 describe('GetActiveProductsUseCase', () => {
@@ -100,11 +100,11 @@ describe('GetActiveProductsUseCase', () => {
       expect(result.meta).toEqual({ limit: 20, hasMore: false, nextCursor: null });
     });
 
-    it('should throw ProductsFetchException wrapping the original error when the repository fails', async () => {
+    it('should throw ProductsFetchError wrapping the original error when the repository fails', async () => {
       const dbError = new Error('DB error');
       findAllActive.mockRejectedValue(dbError);
 
-      await expect(useCase.execute({ limit: 20 })).rejects.toBeInstanceOf(ProductsFetchException);
+      await expect(useCase.execute({ limit: 20 })).rejects.toBeInstanceOf(ProductsFetchError);
       await expect(useCase.execute({ limit: 20 })).rejects.toMatchObject({ cause: dbError });
     });
   });

--- a/src/modules/business-units/application/use-cases/get-active-products.use-case.ts
+++ b/src/modules/business-units/application/use-cases/get-active-products.use-case.ts
@@ -4,7 +4,7 @@ import {
   ProductFilters,
   type IProductRepository,
 } from '../../domain/repositories/product.repository';
-import { ProductsFetchException } from '../errors/product-fetch.exception';
+import { ProductsFetchError } from '../errors/product-fetch.error';
 import { Product } from '../../domain/entities/product.entity';
 import { CursorPaginatedResult, buildCursorMeta } from '@shared/pagination/pagination';
 
@@ -31,7 +31,7 @@ export class GetActiveProductsUseCase {
         filters,
       });
     } catch (err) {
-      throw new ProductsFetchException('Could not retrieve active products.', { cause: err });
+      throw new ProductsFetchError('Could not retrieve active products.', { cause: err });
     }
 
     const hasMore = items.length > limit;

--- a/src/modules/business-units/application/use-cases/get-product-by-id.use-case.spec.ts
+++ b/src/modules/business-units/application/use-cases/get-product-by-id.use-case.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../domain/repositories/product.repository';
 import { GetProductByIdUseCase } from './get-product-by-id.use-case';
 import { Product } from '../../domain/entities/product.entity';
-import { ProductsFetchException } from '../errors/product-fetch.exception';
+import { ProductsFetchError } from '../errors/product-fetch.error';
 
 describe('GetProductByIdUseCase', () => {
   describe('execute', () => {
@@ -68,11 +68,11 @@ describe('GetProductByIdUseCase', () => {
       await expect(useCase.execute('missing-id')).rejects.toBeInstanceOf(NotFoundException);
     });
 
-    it('should throw ProductsFetchException wrapping the original error when the repository fails', async () => {
+    it('should throw ProductsFetchError wrapping the original error when the repository fails', async () => {
       const dbError = new Error('DB error');
       findById.mockRejectedValue(dbError);
 
-      await expect(useCase.execute('uuid-1')).rejects.toBeInstanceOf(ProductsFetchException);
+      await expect(useCase.execute('uuid-1')).rejects.toBeInstanceOf(ProductsFetchError);
       await expect(useCase.execute('uuid-1')).rejects.toMatchObject({ cause: dbError });
     });
   });

--- a/src/modules/business-units/application/use-cases/get-product-by-id.use-case.ts
+++ b/src/modules/business-units/application/use-cases/get-product-by-id.use-case.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { Product } from '../../domain/entities/product.entity';
-import { ProductsFetchException } from '../errors/product-fetch.exception';
+import { ProductsFetchError } from '../errors/product-fetch.error';
 import {
   PRODUCT_REPOSITORY,
   type IProductRepository,
@@ -19,7 +19,7 @@ export class GetProductByIdUseCase {
     try {
       product = await this.products.findById(productId);
     } catch (err) {
-      throw new ProductsFetchException(`Could not retrieve product by id "${productId}".`, {
+      throw new ProductsFetchError(`Could not retrieve product by id "${productId}".`, {
         cause: err,
       });
     }

--- a/src/modules/business-units/application/use-cases/get-products-by-business-unit.use-case.spec.ts
+++ b/src/modules/business-units/application/use-cases/get-products-by-business-unit.use-case.spec.ts
@@ -7,7 +7,7 @@ import {
   PRODUCT_REPOSITORY,
 } from '../../domain/repositories/product.repository';
 import { Product } from '../../domain/entities/product.entity';
-import { ProductsFetchException } from '../errors/product-fetch.exception';
+import { ProductsFetchError } from '../errors/product-fetch.error';
 
 describe('GetProductsByBusinessUnitUseCase', () => {
   let useCase: GetProductsByBusinessUnitUseCase;
@@ -89,12 +89,12 @@ describe('GetProductsByBusinessUnitUseCase', () => {
       expect(result.meta).toEqual({ limit: 20, hasMore: false, nextCursor: null });
     });
 
-    it('should throw ProductsFetchException wrapping the original error when the repository fails', async () => {
+    it('should throw ProductsFetchError wrapping the original error when the repository fails', async () => {
       const dbError = new Error('DB error');
       findAllByBusinessUnit.mockRejectedValue(dbError);
 
       await expect(useCase.execute({ businessUnitId: 'bu-1', limit: 20 })).rejects.toBeInstanceOf(
-        ProductsFetchException,
+        ProductsFetchError,
       );
       await expect(useCase.execute({ businessUnitId: 'bu-1', limit: 20 })).rejects.toMatchObject({
         cause: dbError,

--- a/src/modules/business-units/application/use-cases/get-products-by-business-unit.use-case.ts
+++ b/src/modules/business-units/application/use-cases/get-products-by-business-unit.use-case.ts
@@ -5,7 +5,7 @@ import {
   ProductFilters,
 } from '../../domain/repositories/product.repository';
 import { Product } from '../../domain/entities/product.entity';
-import { ProductsFetchException } from '../errors/product-fetch.exception';
+import { ProductsFetchError } from '../errors/product-fetch.error';
 import { CursorPaginatedResult, buildCursorMeta } from '@shared/pagination/pagination';
 
 export interface GetProductsByBusinessUnitInput {
@@ -33,7 +33,7 @@ export class GetProductsByBusinessUnitUseCase {
         filters,
       });
     } catch (err) {
-      throw new ProductsFetchException(
+      throw new ProductsFetchError(
         `Could not retrieve products for business unit "${businessUnitId}".`,
         { cause: err },
       );

--- a/src/modules/identity/application/errors/users-fetch.error.ts
+++ b/src/modules/identity/application/errors/users-fetch.error.ts
@@ -1,0 +1,8 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+export class UsersFetchError extends ApplicationError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.UNAVAILABLE, message, options);
+  }
+}

--- a/src/modules/identity/application/errors/users-fetch.exception.ts
+++ b/src/modules/identity/application/errors/users-fetch.exception.ts
@@ -1,6 +1,0 @@
-export class UsersFetchException extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.name = 'UsersFetchException';
-  }
-}

--- a/src/modules/identity/application/use-cases/sign-in.use-case.spec.ts
+++ b/src/modules/identity/application/use-cases/sign-in.use-case.spec.ts
@@ -6,7 +6,7 @@ import { IUserRepository, USER_REPOSITORY } from '../../domain/repositories/user
 import { IPasswordHasher, PASSWORD_HASHER } from '../../domain/ports/password-hasher.port';
 import { ITokenSigner, TOKEN_SIGNER } from '../../domain/ports/token-signer.port';
 import { User } from '../../domain/entities/user.entity';
-import { UsersFetchException } from '../errors/users-fetch.exception';
+import { UsersFetchError } from '../errors/users-fetch.error';
 
 describe('SignInUseCase', () => {
   let useCase: SignInUseCase;
@@ -97,11 +97,11 @@ describe('SignInUseCase', () => {
       expect(sign).not.toHaveBeenCalled();
     });
 
-    it('should wrap repository failure in UsersFetchException with cause', async () => {
+    it('should wrap repository failure in UsersFetchError with cause', async () => {
       const dbError = new Error('DB down');
       findByUsername.mockRejectedValue(dbError);
 
-      await expect(useCase.execute('panic', 'plain')).rejects.toBeInstanceOf(UsersFetchException);
+      await expect(useCase.execute('panic', 'plain')).rejects.toBeInstanceOf(UsersFetchError);
       await expect(useCase.execute('panic', 'plain')).rejects.toMatchObject({ cause: dbError });
     });
   });

--- a/src/modules/identity/application/use-cases/sign-in.use-case.ts
+++ b/src/modules/identity/application/use-cases/sign-in.use-case.ts
@@ -4,7 +4,7 @@ import {
   type IUserRepository,
 } from '@modules/identity/domain/repositories/user.repository';
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
-import { UsersFetchException } from '../errors/users-fetch.exception';
+import { UsersFetchError } from '../errors/users-fetch.error';
 import {
   type IPasswordHasher,
   PASSWORD_HASHER,
@@ -28,7 +28,7 @@ export class SignInUseCase {
     try {
       user = await this.users.findByUsername(username);
     } catch (err) {
-      throw new UsersFetchException('Could not retrieve user.', { cause: err });
+      throw new UsersFetchError('Could not retrieve user.', { cause: err });
     }
 
     const isValid = await User.verifyPasswordOrDecoy(user, plainPassword, this.passwordHasher);

--- a/src/shared/errors/application/application.error.ts
+++ b/src/shared/errors/application/application.error.ts
@@ -1,0 +1,11 @@
+import { ErrorKind } from '../errors.type';
+
+export class ApplicationError extends Error {
+  readonly kind: ErrorKind;
+
+  constructor(kind: ErrorKind, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.kind = kind;
+    this.name = new.target.name;
+  }
+}

--- a/src/shared/errors/domain/domain.error.ts
+++ b/src/shared/errors/domain/domain.error.ts
@@ -1,0 +1,11 @@
+import { ErrorKind } from '../errors.type';
+
+export class DomainError extends Error {
+  readonly kind: ErrorKind;
+
+  constructor(kind: ErrorKind, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.kind = kind;
+    this.name = new.target.name;
+  }
+}

--- a/src/shared/errors/error-envelope.type.ts
+++ b/src/shared/errors/error-envelope.type.ts
@@ -1,0 +1,7 @@
+export type ErrorEnvelope = {
+  statusCode: number;
+  error: string;
+  message: string;
+  path: string;
+  timestamp: string;
+};

--- a/src/shared/errors/errors.type.ts
+++ b/src/shared/errors/errors.type.ts
@@ -1,0 +1,19 @@
+export const ERROR_KINDS = {
+  NOT_FOUND: 'not-found',
+  INVALID: 'invalid',
+  CONFLICT: 'conflict',
+  UNAUTHORIZED: 'unauthorized',
+  FORBIDDEN: 'forbidden',
+  UNAVAILABLE: 'unavailable',
+} as const;
+
+export const KIND_TO_STATUS: Record<ErrorKind, number> = {
+  'not-found': 404,
+  invalid: 422,
+  conflict: 409,
+  unauthorized: 401,
+  forbidden: 403,
+  unavailable: 503,
+};
+
+export type ErrorKind = (typeof ERROR_KINDS)[keyof typeof ERROR_KINDS];

--- a/src/shared/filter/global-error.filter.spec.ts
+++ b/src/shared/filter/global-error.filter.spec.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { ArgumentsHost, BadRequestException, HttpException, Logger } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS, type ErrorKind, KIND_TO_STATUS } from '@shared/errors/errors.type';
+import { GlobalErrorFilter } from './global-error.filter';
+import { DomainError } from '@shared/errors/domain/domain.error';
+
+describe('GlobalErrorFilter', () => {
+  let filter: GlobalErrorFilter;
+  let reply: jest.Mock;
+  let getRequestUrl: jest.Mock;
+  let warnSpy: jest.SpiedFunction<typeof Logger.prototype.warn>;
+  let errorSpy: jest.SpiedFunction<typeof Logger.prototype.error>;
+
+  const RESPONSE = {} as unknown;
+
+  const buildHost = (method = 'GET'): ArgumentsHost =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ method }),
+        getResponse: () => RESPONSE,
+      }),
+    }) as unknown as ArgumentsHost;
+
+  beforeEach(() => {
+    reply = jest.fn();
+    getRequestUrl = jest.fn().mockReturnValue('/api/products');
+
+    const httpAdapterHost = {
+      httpAdapter: { reply, getRequestUrl },
+    } as unknown as HttpAdapterHost;
+
+    filter = new GlobalErrorFilter(httpAdapterHost);
+
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('maps an ApplicationError(unavailable) to 503 with the right envelope', () => {
+    const error = new ApplicationError(
+      ERROR_KINDS.UNAVAILABLE,
+      'Could not retrieve active products.',
+    );
+
+    filter.catch(error, buildHost());
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    const [responseArg, body, status] = reply.mock.calls[0];
+
+    expect(responseArg).toBe(RESPONSE);
+    expect(status).toBe(503);
+    expect(body).toEqual({
+      statusCode: 503,
+      error: 'Service Unavailable',
+      message: 'Could not retrieve active products.',
+      path: '/api/products',
+      timestamp: expect.any(String),
+    });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(Object.entries(KIND_TO_STATUS))(
+    'maps kind %s -> status %i in ApplicationError',
+    (kind: string, expectedStatus: number) => {
+      const error = new ApplicationError(kind as ErrorKind, 'fetch failed');
+
+      filter.catch(error, buildHost());
+
+      expect(reply).toHaveBeenCalledTimes(1);
+      const [, , status] = reply.mock.calls[0];
+
+      expect(status).toBe(expectedStatus);
+    },
+  );
+
+  it.each(Object.entries(KIND_TO_STATUS))(
+    'maps kind %s -> status %i in DomainError',
+    (kind: string, expectedStatus: number) => {
+      const error = new DomainError(kind as ErrorKind, 'fetch failed');
+
+      filter.catch(error, buildHost());
+
+      expect(reply).toHaveBeenCalledTimes(1);
+      const [, , status] = reply.mock.calls[0];
+
+      expect(status).toBe(expectedStatus);
+    },
+  );
+
+  it('should return a concatenated error message', () => {
+    const error = new BadRequestException(['Property 1', 'Property 2']);
+
+    filter.catch(error, buildHost());
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    const [, body, status] = reply.mock.calls[0];
+
+    expect(body).toEqual({
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'Property 1, Property 2',
+      path: '/api/products',
+      timestamp: expect.any(String),
+    });
+
+    expect(status).toBe(400);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return the error response even when an HttpException is thrown', () => {
+    const error = new HttpException('Bad Request Message', 400);
+
+    filter.catch(error, buildHost());
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    const [, body, status] = reply.mock.calls[0];
+
+    expect(body).toEqual({
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'Bad Request Message',
+      path: '/api/products',
+      timestamp: expect.any(String),
+    });
+    expect(status).toBe(400);
+  });
+
+  it('should not return an internal secret or stack', () => {
+    const error = new Error('Internal Secret');
+
+    filter.catch(error, buildHost());
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    const [, body, status] = reply.mock.calls[0];
+
+    expect(body).toEqual({
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'Internal Server Error',
+      path: '/api/products',
+      timestamp: expect.any(String),
+    });
+
+    expect(JSON.stringify(body)).not.toContain('Internal Secret');
+
+    expect(status).toBe(500);
+  });
+
+  it.each([
+    'secret string error',
+    null,
+    42,
+    { message: 'secret string in object error' },
+    undefined,
+  ])('should handle a non-error exception %p and return 500', (exception) => {
+    filter.catch(exception, buildHost());
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    const [, body, status] = reply.mock.calls[0];
+
+    expect(JSON.stringify(body)).not.toContain('secret');
+    expect(body).toEqual({
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'Internal Server Error',
+      path: '/api/products',
+      timestamp: expect.any(String),
+    });
+
+    expect(status).toBe(500);
+  });
+
+  it('should log a warning and not call the error logger', () => {
+    const error = new BadRequestException('Bad Request Message');
+
+    filter.catch(error, buildHost());
+    expect(reply).toHaveBeenCalledTimes(1);
+    const [, , status] = reply.mock.calls[0];
+
+    expect(status).toBe(400);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('should log an error and not call the warn logger', () => {
+    const rootCause = new Error('Root cause');
+    const error = new ApplicationError(ERROR_KINDS.UNAVAILABLE, 'Error Message', {
+      cause: new Error('Outer cause', { cause: rootCause }),
+    });
+
+    filter.catch(error, buildHost());
+    expect(reply).toHaveBeenCalledTimes(1);
+    const [, , status] = reply.mock.calls[0];
+
+    expect(status).toBe(503);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const loggedPayload: unknown = errorSpy.mock.calls[0][0];
+
+    expect(loggedPayload).toEqual({
+      causes: ['Outer cause', 'Root cause'],
+      message: 'Error Message',
+      method: 'GET',
+      path: '/api/products',
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not hang on a circular cause chain', () => {
+    const a = new Error('A');
+    const b = new Error('B');
+    a.cause = b;
+    b.cause = a;
+    const error = new ApplicationError(ERROR_KINDS.UNAVAILABLE, 'Circular', {
+      cause: a,
+    });
+
+    filter.catch(error, buildHost());
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const loggedPayload = errorSpy.mock.calls[0][0] as { causes: string[] };
+
+    expect(loggedPayload.causes.length).toBeLessThanOrEqual(5);
+  }, 1000);
+});

--- a/src/shared/filter/global-error.filter.ts
+++ b/src/shared/filter/global-error.filter.ts
@@ -1,0 +1,89 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, Logger } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { DomainError } from '@shared/errors/domain/domain.error';
+import type { ErrorEnvelope } from '@shared/errors/error-envelope.type';
+import { KIND_TO_STATUS } from '@shared/errors/errors.type';
+import { Request } from 'express';
+import { STATUS_CODES } from 'node:http';
+
+@Catch()
+export class GlobalErrorFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalErrorFilter.name);
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const { httpAdapter } = this.httpAdapterHost;
+    const ctx = host.switchToHttp();
+    const ctxRequest = ctx.getRequest<Request>();
+    const path = httpAdapter.getRequestUrl(ctxRequest) as string;
+
+    let statusCode: number;
+    let message: string;
+
+    if (exception instanceof HttpException) {
+      statusCode = exception.getStatus();
+      const res = exception.getResponse();
+
+      if (typeof res === 'string') {
+        message = res;
+      } else {
+        const body = res as { message?: string | string[] };
+        message = Array.isArray(body.message)
+          ? body.message.join(', ')
+          : (body.message ?? 'Internal Server Error');
+      }
+    } else if (exception instanceof ApplicationError || exception instanceof DomainError) {
+      statusCode = KIND_TO_STATUS[exception.kind];
+      message = exception.message;
+    } else {
+      statusCode = 500;
+      message = 'Internal Server Error';
+    }
+
+    const responseBody: ErrorEnvelope = {
+      statusCode,
+      message,
+      error: STATUS_CODES[statusCode] ?? 'Error',
+      timestamp: new Date().toISOString(),
+      path,
+    };
+
+    httpAdapter.reply(ctx.getResponse(), responseBody, statusCode);
+
+    //  =====================================
+    //                  LOGS
+    //  =====================================
+
+    if (statusCode >= 400 && statusCode < 500) {
+      this.logger.warn({
+        message,
+        method: ctxRequest.method,
+        path,
+      });
+    } else if (statusCode >= 500) {
+      this.logger.error(
+        {
+          message,
+          method: ctxRequest.method,
+          path,
+          causes: this.flattenCauses(exception),
+        },
+        exception instanceof Error ? exception.stack : undefined,
+      );
+    }
+  }
+
+  private flattenCauses(err: unknown): string[] {
+    const causes: string[] = [];
+    let current: unknown = err instanceof Error ? err.cause : undefined;
+    const limit = 5;
+
+    while (current instanceof Error && causes.length < limit) {
+      causes.push(current.message);
+      current = current.cause;
+    }
+
+    return causes;
+  }
+}

--- a/test/global-error-filter.e2e-spec.ts
+++ b/test/global-error-filter.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import type { Server } from 'http';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import {
+  IProductRepository,
+  PRODUCT_REPOSITORY,
+} from '@modules/business-units/domain/repositories/product.repository';
+
+/**
+ * Drives a real failure through the full Nest pipeline (global APP_FILTER)
+ * by swapping the product repository for one that always throws.
+ */
+describe('GlobalErrorFilter (e2e)', () => {
+  let app: INestApplication;
+  let server: Server;
+
+  const throwingRepository: IProductRepository = {
+    findById: () => Promise.reject(new Error('SECRET: db credentials in stack')),
+    findAllActive: () => Promise.reject(new Error('SECRET: db credentials in stack')),
+    findAllByBusinessUnit: () => Promise.reject(new Error('SECRET: db credentials in stack')),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(PRODUCT_REPOSITORY)
+      .useValue(throwingRepository)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    server = app.getHttpServer() as Server;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('translates a repository failure into a 503 envelope without leaking internals', async () => {
+    const response = await request(server).get('/api/products').expect(503);
+
+    expect(response.body).toEqual({
+      statusCode: 503,
+      error: 'Service Unavailable',
+      message: 'Could not retrieve active products.',
+      path: '/api/products',
+      timestamp: expect.any(String),
+    });
+    expect(JSON.stringify(response.body)).not.toContain('SECRET');
+  });
+});


### PR DESCRIPTION
Add DomainError/ApplicationError base classes carrying a transport-agnostic `kind`, and a global Nest filter (APP_FILTER) that maps `kind` -> HTTP status, re-wraps NestJS HttpExceptions, returns one consistent JSON envelope, and logs the full Error.cause chain server-side without exposing internals to the client.

- Migrate ProductsFetchException/UsersFetchException to *Error extending ApplicationError (kind: unavailable)
- Register GlobalErrorFilter via APP_FILTER in AppModule
- Bound cause-chain walking so circular causes cannot hang the process
- Unit specs: every kind, HttpException (string/array), non-Error fallback, logging policy, circular chain
- e2e: drive a repository failure through the full pipeline, assert the envelope and that internals do not leak
- Docs: error model, envelope contract, auth section, structure, roadmap

BREAKING CHANGE: error responses now use a fixed envelope { statusCode, error, message, path, timestamp }. Repository/database failures return 503 (was 500). Clients parsing the previous NestJS default error shape must update.