### PR TITLE
feat(validation): global ValidationPipe with explicit DTO conversion …

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Module, ValidationPipe } from '@nestjs/common';
 import { PrismaModule } from '@shared/infrastructure/prisma/prisma.module';
 import { BusinessUnitsModule } from '@modules/business-units/business-units.module';
 import { ConfigModule } from '@nestjs/config';
 import { IdentityModule } from '@modules/identity/identity.module';
-import { APP_FILTER, APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_PIPE } from '@nestjs/core';
 import { AuthGuard } from '@shared/auth/auth.guard';
 import { GlobalErrorFilter } from '@shared/filter/global-error.filter';
 
@@ -22,6 +22,15 @@ import { GlobalErrorFilter } from '@shared/filter/global-error.filter';
     {
       provide: APP_FILTER,
       useClass: GlobalErrorFilter,
+    },
+    {
+      provide: APP_PIPE,
+      useValue: new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: false },
+      }),
     },
   ],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
@@ -9,7 +9,6 @@ async function bootstrap(): Promise<void> {
   app.setGlobalPrefix('api');
   app.enableCors(); // TODO: Configure CORS properly for production
   app.enableShutdownHooks();
-  app.useGlobalPipes(new ValidationPipe());
 
   const port = Number(process.env.PORT) || 3000;
   await app.listen(port);

--- a/src/modules/business-units/infrastructure/http/controllers/products.controller.spec.ts
+++ b/src/modules/business-units/infrastructure/http/controllers/products.controller.spec.ts
@@ -58,7 +58,7 @@ describe('ProductsController', () => {
         meta: { limit: 20, hasMore: false, nextCursor: null },
       });
 
-      const response = await controller.findActive(20, undefined, undefined, undefined);
+      const response = await controller.findActive({ limit: 20 });
 
       expect(response).toBeInstanceOf(PaginatedResponseDto);
       expect(response.data).toHaveLength(1);
@@ -72,7 +72,7 @@ describe('ProductsController', () => {
         meta: { limit: 100, hasMore: false, nextCursor: null },
       });
 
-      await controller.findActive(99999, undefined, undefined, undefined);
+      await controller.findActive({ limit: 99999 });
 
       expect(getActiveProducts.execute).toHaveBeenCalledWith(
         expect.objectContaining({ limit: 100 }),
@@ -85,7 +85,12 @@ describe('ProductsController', () => {
         meta: { limit: 20, hasMore: false, nextCursor: null },
       });
 
-      await controller.findActive(20, 'cursor-id', 'açaí', 'cat-1');
+      await controller.findActive({
+        limit: 20,
+        cursor: 'cursor-id',
+        search: 'açaí',
+        categoryId: 'cat-1',
+      });
 
       expect(getActiveProducts.execute).toHaveBeenCalledWith({
         cursor: 'cursor-id',
@@ -100,7 +105,7 @@ describe('ProductsController', () => {
         meta: { limit: 20, hasMore: false, nextCursor: null },
       });
 
-      await controller.findActive(20, undefined, undefined, undefined);
+      await controller.findActive({ limit: 20 });
 
       expect(getActiveProducts.execute).toHaveBeenCalledWith({
         cursor: undefined,
@@ -118,11 +123,8 @@ describe('ProductsController', () => {
       });
 
       const response = await controller.findByBusinessUnit(
-        'bu-id',
-        20,
-        undefined,
-        undefined,
-        undefined,
+        { businessUnitId: 'bu-id' },
+        { limit: 20 },
       );
 
       expect(getProductsByBusinessUnit.execute).toHaveBeenCalledWith({
@@ -140,7 +142,7 @@ describe('ProductsController', () => {
     it('should return the mapped DTO when the product exists', async () => {
       getProductById.execute.mockResolvedValue(buildProduct('uuid-42'));
 
-      const response = await controller.findById('uuid-42');
+      const response = await controller.findById({ productId: 'uuid-42' });
 
       expect(getProductById.execute).toHaveBeenCalledWith('uuid-42');
       expect(response).toBeInstanceOf(ProductResponseDto);
@@ -150,7 +152,9 @@ describe('ProductsController', () => {
     it('should propagate NotFoundException raised by the use-case', async () => {
       getProductById.execute.mockRejectedValue(new NotFoundException('Product not found.'));
 
-      await expect(controller.findById('missing')).rejects.toBeInstanceOf(NotFoundException);
+      await expect(controller.findById({ productId: 'missing' })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/modules/business-units/infrastructure/http/controllers/products.controller.ts
+++ b/src/modules/business-units/infrastructure/http/controllers/products.controller.ts
@@ -1,12 +1,17 @@
-import { Controller, DefaultValuePipe, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { GetActiveProductsUseCase } from '../../../application/use-cases/get-active-products.use-case';
 import { GetProductsByBusinessUnitUseCase } from '../../../application/use-cases/get-products-by-business-unit.use-case';
 import { GetProductByIdUseCase } from '../../../application/use-cases/get-product-by-id.use-case';
 import { ProductResponseDto } from '../dto/product-response.dto';
 import { PaginatedResponseDto } from '@shared/pagination/paginated-response.dto';
-import { sanitizeLimit, DEFAULT_LIMIT } from '@shared/pagination/pagination';
+import { sanitizeLimit } from '@shared/pagination/pagination';
 import { ProductFilters } from '../../../domain/repositories/product.repository';
 import { Public } from '@shared/auth/public.decorator';
+import {
+  BusinessUnitIdParamDto,
+  ProductIdParamDto,
+  ProductsQueryDto,
+} from '../dto/product-query.dto';
 
 @Controller('products')
 export class ProductsController {
@@ -19,11 +24,9 @@ export class ProductsController {
   @Public()
   @Get()
   async findActive(
-    @Query('limit', new DefaultValuePipe(DEFAULT_LIMIT), ParseIntPipe) rawLimit: number,
-    @Query('cursor') cursor: string | undefined,
-    @Query('search') search: string | undefined,
-    @Query('categoryId') categoryId: string | undefined,
+    @Query() query: ProductsQueryDto,
   ): Promise<PaginatedResponseDto<ProductResponseDto>> {
+    const { limit: rawLimit, categoryId, search, cursor } = query;
     const limit = sanitizeLimit(rawLimit);
     const filters = this.buildFilters(search, categoryId);
 
@@ -38,12 +41,10 @@ export class ProductsController {
   @Public()
   @Get('by-business-unit/:businessUnitId')
   async findByBusinessUnit(
-    @Param('businessUnitId') businessUnitId: string,
-    @Query('limit', new DefaultValuePipe(DEFAULT_LIMIT), ParseIntPipe) rawLimit: number,
-    @Query('cursor') cursor: string | undefined,
-    @Query('search') search: string | undefined,
-    @Query('categoryId') categoryId: string | undefined,
+    @Param() { businessUnitId }: BusinessUnitIdParamDto,
+    @Query() query: ProductsQueryDto,
   ): Promise<PaginatedResponseDto<ProductResponseDto>> {
+    const { limit: rawLimit, categoryId, search, cursor } = query;
     const limit = sanitizeLimit(rawLimit);
     const filters = this.buildFilters(search, categoryId);
 
@@ -62,7 +63,7 @@ export class ProductsController {
 
   @Public()
   @Get(':productId')
-  async findById(@Param('productId') productId: string): Promise<ProductResponseDto> {
+  async findById(@Param() { productId }: ProductIdParamDto): Promise<ProductResponseDto> {
     const product = await this.getProductById.execute(productId);
     return ProductResponseDto.fromEntity(product);
   }

--- a/src/modules/business-units/infrastructure/http/dto/product-query.dto.ts
+++ b/src/modules/business-units/infrastructure/http/dto/product-query.dto.ts
@@ -1,0 +1,31 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class ProductsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  limit?: number;
+
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+}
+
+export class BusinessUnitIdParamDto {
+  @IsUUID()
+  businessUnitId!: string;
+}
+
+export class ProductIdParamDto {
+  @IsUUID()
+  productId!: string;
+}

--- a/test/validation-pipe.e2e-spec.ts
+++ b/test/validation-pipe.e2e-spec.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import type { Server } from 'http';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+/**
+ * Proves the global ValidationPipe (registered as APP_PIPE in AppModule)
+ * is active across the full Nest pipeline:
+ *  - extra/unknown properties  -> 400 (forbidNonWhitelisted)
+ *  - wrong types               -> 400 (type validation, explicit @Type only)
+ *  - well-formed payloads      -> pass through to the use-case
+ *
+ * The pipe is asserted through real HTTP, NOT by calling controllers
+ * directly, because validation only runs in the HTTP pipeline.
+ *
+ * transformOptions.enableImplicitConversion is OFF by design: conversion
+ * is opt-in per field via @Type(). So a non-string in a @IsString field
+ * is NOT coerced and is rejected with 400 (see the username test).
+ */
+describe('ValidationPipe (e2e)', () => {
+  let app: INestApplication;
+  let server: Server;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    server = app.getHttpServer() as Server;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('forbidNonWhitelisted — unknown properties rejected', () => {
+    it('rejects a login body carrying an extra field (400)', async () => {
+      // username/password are valid on their own, so 400 is caused
+      // *only* by the unknown `role` field -> proves forbidNonWhitelisted.
+      await request(server)
+        .post('/api/auth/login')
+        .send({ username: 'someone', password: 'supersecret', role: 'ADMIN' })
+        .expect(400);
+    });
+
+    it('rejects an unknown query param on the products list (400)', async () => {
+      await request(server).get('/api/products?foo=bar').expect(400);
+    });
+  });
+
+  describe('type validation — wrong types rejected', () => {
+    // DoD: "string in a number field -> 400". @Type(() => Number) coerces
+    // "abc" -> NaN, then @IsInt fails.
+    it('rejects a non-numeric "limit" query param (400)', async () => {
+      await request(server).get('/api/products?limit=abc').expect(400);
+    });
+
+    // With enableImplicitConversion OFF and no @Type on username, 12345
+    // stays a number, so @IsString rejects it -> 400. Under implicit
+    // conversion this would be stringified first and slip through.
+    it('rejects a non-string username in the login body (400)', async () => {
+      await request(server)
+        .post('/api/auth/login')
+        .send({ username: 12345, password: 'supersecret' })
+        .expect(400);
+    });
+
+    it('rejects a malformed UUID path param (400)', async () => {
+      await request(server).get('/api/products/not-a-uuid').expect(400);
+    });
+  });
+
+  describe('valid payloads pass the pipe', () => {
+    it('accepts the products list with no query params (200)', async () => {
+      await request(server).get('/api/products').expect(200);
+    });
+
+    it('coerces a valid numeric "limit" via explicit @Type (200)', async () => {
+      // Proves @Type(() => Number) still converts the query string with
+      // implicit conversion OFF — @Type is now load-bearing, not redundant.
+      await request(server).get('/api/products?limit=5').expect(200);
+    });
+
+    it('clamps an out-of-range "limit" instead of rejecting it (200)', async () => {
+      // By design: limit bounds are clamped by sanitizeLimit, not
+      // rejected by @Max. ?limit=99999 -> clamped to MAX_LIMIT, 200.
+      await request(server).get('/api/products?limit=99999').expect(200);
+    });
+
+    it('lets a well-formed login through to the use-case (not 400)', async () => {
+      // Unknown user -> the use-case rejects it (401), but the request
+      // reached the use-case at all, proving the pipe let it through.
+      const response = await request(server)
+        .post('/api/auth/login')
+        .send({ username: 'nonexistent-user', password: 'supersecret' });
+
+      expect(response.status).not.toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
…(#9)

Register ValidationPipe as APP_PIPE (consistent with APP_FILTER/APP_GUARD) with whitelist, forbidNonWhitelisted, transform, and implicit conversion disabled — conversion is opt-in per field via @Type().

- add ProductsQueryDto/BusinessUnitIdParamDto/ProductIdParamDto and bind whole-object @Query()/@Param() in ProductsController
- remove imperative useGlobalPipes() from main.ts
- update controller unit tests to the new DTO-object signatures
- add validation-pipe e2e suite covering RN-9's DoD

Behavior change: a malformed UUID path param now returns 400 (was 404); an out-of-range ?limit is still clamped, not rejected, by sanitizeLimit.

Closes #9