### PR TITLE
feat(swagger): expose OpenAPI docs at /api/docs and annotate products…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.4.3",
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
         "argon2": "^0.44.0",
@@ -2632,6 +2633,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
@@ -3403,6 +3410,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.19",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.19.tgz",
@@ -3507,6 +3534,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.3.tgz",
+      "integrity": "sha512-LR4BuOj+iBFzhGRnNP0OHjmrPXliDEjrmniXtLsfLDIELjkuUXYCTGjZMqgDdOY+QSabeF59LndaDzOOe+vMmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.6"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -3989,6 +4049,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -6197,7 +6264,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -10527,7 +10593,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13549,6 +13614,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raizes-do-nordeste",
   "version": "0.0.1",
-  "description": "",
+  "description": "Multi-unit restaurant management API for Raízes do Nordeste",
   "author": "Marcos Paulo Freire Almeida",
   "private": true,
   "license": "UNLICENSED",
@@ -35,6 +35,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.4.3",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "argon2": "^0.44.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,8 +11,8 @@ import { GlobalErrorFilter } from '@shared/filter/global-error.filter';
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     PrismaModule,
-    BusinessUnitsModule,
     IdentityModule,
+    BusinessUnitsModule,
   ],
   providers: [
     {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,23 @@
 import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { AppModule } from './app.module';
+
+function readAppVersion(): string {
+  const raw: unknown = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+  if (
+    raw !== null &&
+    typeof raw === 'object' &&
+    'version' in raw &&
+    typeof raw.version === 'string'
+  ) {
+    return raw.version;
+  }
+  return '0.0.0';
+}
 
 async function bootstrap(): Promise<void> {
   const logger = new Logger('Bootstrap');
@@ -11,6 +28,25 @@ async function bootstrap(): Promise<void> {
   app.enableShutdownHooks();
 
   const port = Number(process.env.PORT) || 3000;
+
+  const configService = app.get(ConfigService);
+  const isProduction = configService.get<string>('NODE_ENV') === 'production';
+
+  if (!isProduction) {
+    const config = new DocumentBuilder()
+      .setTitle('Raízes do Nordeste')
+      .setDescription('Multi-unit restaurant management API for Raízes do Nordeste')
+      .setVersion(readAppVersion())
+      .addBearerAuth()
+      .build();
+
+    const documentFactory = (): ReturnType<typeof SwaggerModule.createDocument> =>
+      SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('docs', app, documentFactory, { useGlobalPrefix: true });
+
+    logger.log(`Swagger UI available at http://localhost:${port}/api/docs`);
+  }
+
   await app.listen(port);
 
   logger.log(`Application running on http://localhost:${port}/api`);

--- a/src/modules/business-units/infrastructure/http/controllers/products.controller.ts
+++ b/src/modules/business-units/infrastructure/http/controllers/products.controller.ts
@@ -1,4 +1,6 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { PaginatedProductResponseDto } from '../dto/paginated-product-response.dto';
 import { GetActiveProductsUseCase } from '../../../application/use-cases/get-active-products.use-case';
 import { GetProductsByBusinessUnitUseCase } from '../../../application/use-cases/get-products-by-business-unit.use-case';
 import { GetProductByIdUseCase } from '../../../application/use-cases/get-product-by-id.use-case';
@@ -13,6 +15,7 @@ import {
   ProductsQueryDto,
 } from '../dto/product-query.dto';
 
+@ApiTags('products')
 @Controller('products')
 export class ProductsController {
   constructor(
@@ -23,6 +26,8 @@ export class ProductsController {
 
   @Public()
   @Get()
+  @ApiOperation({ summary: 'List active products (cursor-paginated)' })
+  @ApiOkResponse({ type: PaginatedProductResponseDto })
   async findActive(
     @Query() query: ProductsQueryDto,
   ): Promise<PaginatedResponseDto<ProductResponseDto>> {
@@ -40,6 +45,8 @@ export class ProductsController {
 
   @Public()
   @Get('by-business-unit/:businessUnitId')
+  @ApiOperation({ summary: 'List active products for a business unit' })
+  @ApiOkResponse({ type: PaginatedProductResponseDto })
   async findByBusinessUnit(
     @Param() { businessUnitId }: BusinessUnitIdParamDto,
     @Query() query: ProductsQueryDto,
@@ -63,6 +70,20 @@ export class ProductsController {
 
   @Public()
   @Get(':productId')
+  @ApiOperation({ summary: 'Get a product by ID' })
+  @ApiOkResponse({ type: ProductResponseDto })
+  @ApiNotFoundResponse({
+    description: 'Product not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Product not found',
+        path: '/api/products/550e8400-e29b-41d4-a716-446655440000',
+        timestamp: '2026-05-18T10:30:00.000Z',
+      },
+    },
+  })
   async findById(@Param() { productId }: ProductIdParamDto): Promise<ProductResponseDto> {
     const product = await this.getProductById.execute(productId);
     return ProductResponseDto.fromEntity(product);

--- a/src/modules/business-units/infrastructure/http/dto/paginated-product-response.dto.ts
+++ b/src/modules/business-units/infrastructure/http/dto/paginated-product-response.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ProductResponseDto } from './product-response.dto';
+
+/**
+ * Schema-only DTO: never instantiated at runtime. It exists so Swagger can
+ * describe the generic `PaginatedResponseDto<ProductResponseDto>` returned by
+ * the list endpoints (OpenAPI has no generics — a concrete class is needed).
+ * Keep its shape in sync with `PaginatedResponseDto` + `CursorPaginationMeta`.
+ */
+class CursorPaginationMetaDto {
+  @ApiProperty({ example: 20, description: 'Applied page size' })
+  public readonly limit!: number;
+
+  @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    type: String,
+    nullable: true,
+    description: 'Cursor for the next page; null when there are no more items',
+  })
+  public readonly nextCursor!: string | null;
+
+  @ApiProperty({ example: true })
+  public readonly hasMore!: boolean;
+}
+
+export class PaginatedProductResponseDto {
+  @ApiProperty({ type: [ProductResponseDto] })
+  public readonly data!: ProductResponseDto[];
+
+  @ApiProperty({ type: CursorPaginationMetaDto })
+  public readonly meta!: CursorPaginationMetaDto;
+}

--- a/src/modules/business-units/infrastructure/http/dto/product-query.dto.ts
+++ b/src/modules/business-units/infrastructure/http/dto/product-query.dto.ts
@@ -1,31 +1,55 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class ProductsQueryDto {
+  @ApiPropertyOptional({
+    example: 20,
+    minimum: 1,
+    maximum: 100,
+    description: 'Items per page (default 20, max 100)',
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   limit?: number;
 
+  @ApiPropertyOptional({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    description: 'ID of the last item from the previous page (cursor)',
+  })
   @IsOptional()
   @IsString()
   cursor?: string;
 
+  @ApiPropertyOptional({
+    example: '7c9e6679-7425-40de-944b-e07fc1f90ae7',
+    format: 'uuid',
+  })
   @IsOptional()
   @IsUUID()
   categoryId?: string;
 
+  @ApiPropertyOptional({ example: 'Juice' })
   @IsOptional()
   @IsString()
   search?: string;
 }
 
 export class BusinessUnitIdParamDto {
+  @ApiProperty({
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    format: 'uuid',
+  })
   @IsUUID()
   businessUnitId!: string;
 }
 
 export class ProductIdParamDto {
+  @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    format: 'uuid',
+  })
   @IsUUID()
   productId!: string;
 }

--- a/src/modules/business-units/infrastructure/http/dto/product-response.dto.ts
+++ b/src/modules/business-units/infrastructure/http/dto/product-response.dto.ts
@@ -1,16 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Product } from '../../../domain/entities/product.entity';
 
 export class ProductResponseDto {
+  @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    format: 'uuid',
+  })
+  public readonly id: string;
+
+  @ApiProperty({ example: 'Acarajé' })
+  public readonly name: string;
+
+  @ApiProperty({
+    example: 'Black-eyed pea fritter fried in dendê palm oil',
+    type: String,
+    nullable: true,
+  })
+  public readonly description: string | null;
+
+  @ApiProperty({ example: 18.5, description: 'Price in BRL' })
+  public readonly price: number;
+
+  @ApiProperty({ example: true })
+  public readonly isActive: boolean;
+
+  @ApiProperty({
+    example: '7c9e6679-7425-40de-944b-e07fc1f90ae7',
+    format: 'uuid',
+  })
+  public readonly categoryId: string;
+
+  @ApiProperty({ example: '2026-05-18T10:30:00.000Z' })
+  public readonly createdAt: Date;
+
+  @ApiProperty({ example: '2026-05-18T10:30:00.000Z' })
+  public readonly updatedAt: Date;
+
   constructor(
-    public readonly id: string,
-    public readonly name: string,
-    public readonly description: string | null,
-    public readonly price: number,
-    public readonly isActive: boolean,
-    public readonly categoryId: string,
-    public readonly createdAt: Date,
-    public readonly updatedAt: Date,
-  ) {}
+    id: string,
+    name: string,
+    description: string | null,
+    price: number,
+    isActive: boolean,
+    categoryId: string,
+    createdAt: Date,
+    updatedAt: Date,
+  ) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.price = price;
+    this.isActive = isActive;
+    this.categoryId = categoryId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
 
   static fromEntity(product: Product): ProductResponseDto {
     return new ProductResponseDto(


### PR DESCRIPTION
… (#10/#11)

Set up @nestjs/swagger with DocumentBuilder: bearer auth, version read from package.json, gated to non-production, served under the global prefix at /api/docs.

Annotate ProductsController and its DTOs (@ApiTags/@ApiOperation/ @ApiOkResponse/@ApiNotFoundResponse, examples) and add a concrete PaginatedProductResponseDto to describe the generic list envelope, since OpenAPI has no generics.

Refactor ProductResponseDto from constructor parameter properties to declared fields — required because @ApiProperty cannot decorate constructor params; constructor signature unchanged, specs unaffected.

Closes #10, #11