### PR TITLE
docs: add JSDoc to non-obvious domain seams and base classes

### DIFF
--- a/src/modules/identity/domain/entities/user.entity.ts
+++ b/src/modules/identity/domain/entities/user.entity.ts
@@ -17,6 +17,12 @@ export class User {
     public readonly isActive: boolean,
   ) {}
 
+  /**
+   * Verifies a password without leaking whether the username exists. When `user`
+   * is `null` it still calls {@link PasswordHasher.verify} against a decoy so the
+   * work (and timing) matches the real path, defeating user-enumeration by response
+   * time. Always returns `false` for an unknown user.
+   */
   static async verifyPasswordOrDecoy(
     user: User | null,
     plainPassword: string,

--- a/src/modules/identity/domain/ports/password-hasher.port.ts
+++ b/src/modules/identity/domain/ports/password-hasher.port.ts
@@ -1,5 +1,11 @@
+/** Hashes and verifies passwords; the application depends on this seam, not on argon2. */
 export interface PasswordHasher {
   hash(plainPassword: string): Promise<string>;
+  /**
+   * Checks `plainPassword` against `passwordHash`. A `null` hash is the decoy case
+   * (no such user): it still performs a comparison so timing stays constant, and
+   * always resolves `false`. See {@link User.verifyPasswordOrDecoy}.
+   */
   verify(passwordHash: string | null, plainPassword: string): Promise<boolean>;
 }
 

--- a/src/modules/identity/domain/ports/token-signer.port.ts
+++ b/src/modules/identity/domain/ports/token-signer.port.ts
@@ -1,5 +1,6 @@
 import { JwtPayloadSign } from '@shared/auth/jwt-payload.type';
 
+/** Signs an access token from a payload; the seam between the application and the JWT adapter. */
 export interface TokenSigner {
   sign(payload: JwtPayloadSign): Promise<string>;
 }

--- a/src/modules/orders/domain/entities/order-item.entity.ts
+++ b/src/modules/orders/domain/entities/order-item.entity.ts
@@ -1,6 +1,7 @@
 import Big from 'big.js';
 
 export class OrderItem {
+  /** Line total (`quantity × unitPrice`), computed once at construction with `big.js` — never a float. */
   public readonly subtotal: Big;
 
   constructor(
@@ -14,6 +15,7 @@ export class OrderItem {
     this.subtotal = OrderItem.calculateSubtotal(quantity, unitPrice);
   }
 
+  /** Accepts `unitPrice` as `Big` or `string` so callers can compute a subtotal before an instance exists. */
   static calculateSubtotal(quantity: number, unitPrice: Big | string): Big {
     return new Big(quantity).times(new Big(unitPrice));
   }

--- a/src/modules/orders/domain/value-objects/order-channel.ts
+++ b/src/modules/orders/domain/value-objects/order-channel.ts
@@ -8,6 +8,12 @@ export const OrderChannel = {
 
 export type OrderChannel = (typeof OrderChannel)[keyof typeof OrderChannel];
 
+/**
+ * Where the order's customer comes from:
+ * - `authenticated`: the logged-in user placing the order (APP, WEB).
+ * - `anonymous`: no customer is attached — a walk-up self-service order (TOTEM).
+ * - `from-request`: a staff member supplies the customer in the request body (COUNTER, PICKUP).
+ */
 type CustomerSource = 'authenticated' | 'anonymous' | 'from-request';
 
 interface ChannelPolicy {
@@ -15,6 +21,11 @@ interface ChannelPolicy {
   customerSource: CustomerSource;
 }
 
+/**
+ * Per-channel rules: whether a staff attendant must place the order, and how its
+ * customer is resolved. This table is the single source of truth — callers ask via
+ * the helpers below instead of branching on the channel.
+ */
 const POLICIES: Record<OrderChannel, ChannelPolicy> = {
   APP: { requiresAttendant: false, customerSource: 'authenticated' },
   WEB: { requiresAttendant: false, customerSource: 'authenticated' },

--- a/src/shared/auth/auth.guard.ts
+++ b/src/shared/auth/auth.guard.ts
@@ -19,6 +19,12 @@ export class AuthGuard implements CanActivate {
     private readonly jwtService: JwtService,
   ) {}
 
+  /**
+   * Two-phase gate. First, `@Public()` handlers bypass auth entirely. Otherwise the
+   * Bearer JWT must verify (401 on missing/invalid) and its payload is attached to the
+   * request. Then authorization: with no `@Roles()` any authenticated user passes; with
+   * `@Roles()` the user's role must be in the list.
+   */
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),

--- a/src/shared/errors/application/application.error.ts
+++ b/src/shared/errors/application/application.error.ts
@@ -1,5 +1,11 @@
 import { ErrorKind } from '../errors.type';
 
+/**
+ * Base class for application-layer failures (use cases orchestrating work, often
+ * wrapping an infrastructure error via `cause`). Carries a transport-agnostic
+ * {@link ErrorKind} the global filter maps to an HTTP status. `new.target.name`
+ * sets `name` to the actual subclass (e.g. `OrdersFetchError`), not `ApplicationError`.
+ */
 export class ApplicationError extends Error {
   readonly kind: ErrorKind;
 

--- a/src/shared/errors/domain/domain.error.ts
+++ b/src/shared/errors/domain/domain.error.ts
@@ -1,5 +1,11 @@
 import { ErrorKind } from '../errors.type';
 
+/**
+ * Base class for domain-rule violations (invariants broken in `domain/`). Carries a
+ * transport-agnostic {@link ErrorKind} that the global filter maps to an HTTP status —
+ * the domain never throws `HttpException`. `new.target.name` sets `name` to the actual
+ * subclass (e.g. `InvalidOrderStatusTransitionError`), not `DomainError`.
+ */
 export class DomainError extends Error {
   readonly kind: ErrorKind;
 


### PR DESCRIPTION
Document only behavior that isn't self-evident, matching the existing WHY-over-WHAT convention (no gold-plating):

- User.verifyPasswordOrDecoy: anti-enumeration / constant-time path
- PasswordHasher/TokenSigner ports: contract + why the hash is nullable
- order-channel: POLICIES table and CustomerSource semantics
- DomainError/ApplicationError: kind mapping + new.target.name
- OrderItem.subtotal: big.js line total, never a float
- AuthGuard.canActivate: two-phase public/auth/roles gate

Comment-only; no logic changes. lint/build clean, 193 tests green.