### PR TITLE
fix(orders): stop updateStatus re-read from leaking a 500 on a delete…

### DIFF
--- a/src/modules/orders/infrastructure/persistence/prisma-order.repository.spec.ts
+++ b/src/modules/orders/infrastructure/persistence/prisma-order.repository.spec.ts
@@ -10,7 +10,6 @@ import { OrderReferenceNotFoundError } from '@modules/orders/domain/errors/order
 
 type OrderCreateFn = (args: unknown) => Promise<PersistedOrderRow>;
 type OrderFindUniqueFn = (args: unknown) => Promise<PersistedOrderRow | null>;
-type OrderFindUniqueOrThrowFn = (args: unknown) => Promise<PersistedOrderRow>;
 type OrderFindManyFn = (args: unknown) => Promise<PersistedOrderRow[]>;
 type OrderUpdateManyFn = (args: unknown) => Promise<{ count: number }>;
 
@@ -49,7 +48,6 @@ const knownError = (code: string, fieldName?: string): Prisma.PrismaClientKnownR
 describe('PrismaOrderRepository', () => {
   let create: jest.MockedFunction<OrderCreateFn>;
   let findUnique: jest.MockedFunction<OrderFindUniqueFn>;
-  let findUniqueOrThrow: jest.MockedFunction<OrderFindUniqueOrThrowFn>;
   let findMany: jest.MockedFunction<OrderFindManyFn>;
   let updateMany: jest.MockedFunction<OrderUpdateManyFn>;
   let repo: PrismaOrderRepository;
@@ -107,11 +105,10 @@ describe('PrismaOrderRepository', () => {
   beforeEach(() => {
     create = jest.fn() as jest.MockedFunction<OrderCreateFn>;
     findUnique = jest.fn() as jest.MockedFunction<OrderFindUniqueFn>;
-    findUniqueOrThrow = jest.fn() as jest.MockedFunction<OrderFindUniqueOrThrowFn>;
     findMany = jest.fn() as jest.MockedFunction<OrderFindManyFn>;
     updateMany = jest.fn() as jest.MockedFunction<OrderUpdateManyFn>;
     const prisma = {
-      order: { create, findUnique, findUniqueOrThrow, findMany, updateMany },
+      order: { create, findUnique, findMany, updateMany },
     } as unknown as PrismaService;
     repo = new PrismaOrderRepository(prisma);
   });
@@ -261,7 +258,7 @@ describe('PrismaOrderRepository', () => {
 
     it('applies the conditional update and returns the re-read Order when a row matched', async () => {
       updateMany.mockResolvedValue({ count: 1 });
-      findUniqueOrThrow.mockResolvedValue({
+      findUnique.mockResolvedValue({
         ...persistedRow,
         orderStatus: 'CONFIRMED',
         updatedById: 'staff-1',
@@ -273,7 +270,7 @@ describe('PrismaOrderRepository', () => {
         where: { id: 'order-1', orderStatus: 'PENDING' },
         data: { orderStatus: 'CONFIRMED', updatedById: 'staff-1' },
       });
-      expect(findUniqueOrThrow).toHaveBeenCalledWith({
+      expect(findUnique).toHaveBeenCalledWith({
         where: { id: 'order-1' },
         include: { orderItems: true },
       });
@@ -285,7 +282,14 @@ describe('PrismaOrderRepository', () => {
       updateMany.mockResolvedValue({ count: 0 });
 
       await expect(repo.updateStatus(updateInput)).resolves.toBeNull();
-      expect(findUniqueOrThrow).not.toHaveBeenCalled();
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the row vanished between the update and the re-read', async () => {
+      updateMany.mockResolvedValue({ count: 1 });
+      findUnique.mockResolvedValue(null);
+
+      await expect(repo.updateStatus(updateInput)).resolves.toBeNull();
     });
 
     it('translates a P2003 foreign-key violation into OrderReferenceNotFoundError, chaining the cause', async () => {

--- a/src/modules/orders/infrastructure/persistence/prisma-order.repository.ts
+++ b/src/modules/orders/infrastructure/persistence/prisma-order.repository.ts
@@ -45,15 +45,7 @@ export class PrismaOrderRepository implements OrderRepository {
 
       return this.toEntity(fullOrder);
     } catch (err) {
-      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
-        const reference = this.classifyForeignKey(err.meta);
-        throw new OrderReferenceNotFoundError(
-          `Order references a ${reference} that does not exist.`,
-          { cause: err },
-        );
-      }
-
-      throw err;
+      this.mapForeignKeyError(err);
     }
   }
 
@@ -96,21 +88,14 @@ export class PrismaOrderRepository implements OrderRepository {
         return null;
       }
 
-      const updated = await this.prisma.order.findUniqueOrThrow({
+      const updated = await this.prisma.order.findUnique({
         where: { id: input.id },
         include: { orderItems: true },
       });
-      return this.toEntity(updated);
+      // Vanished between the update and the re-read (delete race): treat as a conflict.
+      return updated ? this.toEntity(updated) : null;
     } catch (err) {
-      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
-        const reference = this.classifyForeignKey(err.meta);
-        throw new OrderReferenceNotFoundError(
-          `Order references a ${reference} that does not exist.`,
-          { cause: err },
-        );
-      }
-
-      throw err;
+      this.mapForeignKeyError(err);
     }
   }
 
@@ -131,6 +116,18 @@ export class PrismaOrderRepository implements OrderRepository {
       where.orderStatus = filters.orderStatus;
     }
     return where;
+  }
+
+  /** Maps a Prisma FK violation (P2003) to a domain error; rethrows anything else. */
+  private mapForeignKeyError(err: unknown): never {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
+      throw new OrderReferenceNotFoundError(
+        `Order references a ${this.classifyForeignKey(err.meta)} that does not exist.`,
+        { cause: err },
+      );
+    }
+
+    throw err;
   }
 
   private classifyForeignKey(meta: unknown): string {


### PR DESCRIPTION
… race

After the optimistic updateMany matched (count=1), the re-read used findUniqueOrThrow. If the order vanished in the window between the two statements, Prisma throws P2025, which the catch (P2003 only) let through, so GlobalErrorFilter returned a raw 500. Use findUnique and treat null as "no result": the use case already maps it to OrderStatusConflictError (409).

Also extract the duplicated P2003 -> OrderReferenceNotFoundError mapping (verbatim in create() and updateStatus()) into a private mapForeignKeyError helper, so the FK-classification wording stays in one place.