### PR TITLE
feat(payments): add retriable payment attempts with webhook settlement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ NODE_ENV=development
 PORT=3000
 
 JWT_SECRET_KEY=
+
+# Shared secret the payment gateway webhook must send in the "x-webhook-secret" header.
+PAYMENT_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Raízes do Nordeste — Backend API
+# Raízes do Nordeste - Backend API
 
 [![CI](https://github.com/M4rcosz/raizes-do-nordeste/actions/workflows/ci.yml/badge.svg)](https://github.com/M4rcosz/raizes-do-nordeste/actions/workflows/ci.yml)
 
 REST API for a multi-unit restaurant ordering system. The platform powers menu
 browsing, order management, payment processing, inventory control and a
-customer loyalty program — across multiple business units (franchises).
+customer loyalty program - across multiple business units (franchises).
 
 > **Status:** the project is being built incrementally. The shipped surface
 > is the product catalog (public browsing + role-gated creation), identity
 > (JWT login + argon2 hashing + global role guard), a cross-cutting audit
-> log wired into the login flow, and a first slice of **orders**
-> (channel-aware `POST /api/orders` with server-side total). Payments,
-> inventory, promotions and loyalty are planned (see [Roadmap](#roadmap)).
+> log wired into the login flow, **orders** (channel-aware creation, reads,
+> status state machine), and **payments** (gateway charge + webhook
+> confirmation that advances the order). Inventory, promotions and loyalty
+> are planned (see [Roadmap](#roadmap)).
 
 ---
 
@@ -49,9 +50,9 @@ customer loyalty program — across multiple business units (franchises).
 
 ## Architecture
 
-The codebase follows **Clean Architecture organized by bounded context** — each
+The codebase follows **Clean Architecture organized by bounded context** - each
 business context owns its own four-layer stack, and dependencies point strictly
-inwards (infrastructure → application → domain).
+inwards (infrastructure -> application -> domain).
 
 ```
    ┌────────────────────────────────────────────────────────┐
@@ -61,7 +62,7 @@ inwards (infrastructure → application → domain).
                                │ depends on
    ┌───────────────────────────▼────────────────────────────┐
    │                    Application Layer                   │  Orchestration
-   │            (Use Cases — one per business action)       │
+   │            (Use Cases - one per business action)       │
    └───────────────────────────┬────────────────────────────┘
                                │ depends on
    ┌───────────────────────────▼────────────────────────────┐
@@ -75,7 +76,7 @@ inwards (infrastructure → application → domain).
    └────────────────────────────────────────────────────────┘
 ```
 
-> **Heads-up — structural change mid-project (May 2026):** the codebase was
+> **Heads-up - structural change mid-project (May 2026):** the codebase was
 > refactored from a flat layout (`src/domain`, `src/infrastructure`,
 > `src/modules/<feature>`) into a per-bounded-context layout
 > (`src/modules/<context>/{domain,application,infrastructure}`). The flat
@@ -90,10 +91,10 @@ inwards (infrastructure → application → domain).
 ### Architectural Decisions
 
 **1. Clean Architecture with NestJS pragmatism**
-The `domain/` layer of each context contains pure TypeScript — no NestJS, no
+The `domain/` layer of each context contains pure TypeScript - no NestJS, no
 Prisma, no framework imports. This keeps business rules portable and trivial
 to unit test. Use cases, however, use `@Injectable()` so the DI container can
-wire them up — this is a deliberate, accepted compromise for ergonomics.
+wire them up - this is a deliberate, accepted compromise for ergonomics.
 
 **2. Repository Pattern**
 Each context's `domain/repositories/` declares interfaces. The matching
@@ -128,15 +129,15 @@ likewise validated as decimal strings (`@IsDecimal`) and never coerced via
 - Domain and application errors extend shared base classes
   (`DomainError` / `ApplicationError`) that carry a transport-agnostic
   `kind` (`not-found`, `invalid`, `conflict`, `unauthorized`, `forbidden`,
-  `unavailable`) — never an HTTP status.
+  `unavailable`) - never an HTTP status.
 - A global exception filter (`shared/filter/`, registered via `APP_FILTER`)
-  is the single place that maps `kind` → HTTP status, re-wraps NestJS
+  is the single place that maps `kind` -> HTTP status, re-wraps NestJS
   `HttpException`s, and emits one consistent JSON envelope. It logs the full
   `Error.cause` chain server-side but never leaks internals to the client.
 - `ProductsFetchError` (application layer) wraps the underlying repository
   failure with the standard `Error.cause` option and `kind: unavailable`.
 - Repositories translate persistence-specific failures into domain errors at
-  the boundary — a Prisma `P2002` unique-constraint violation becomes
+  the boundary - a Prisma `P2002` unique-constraint violation becomes
   `ProductAlreadyExistsError` (`kind: conflict`) and a `P2003` foreign-key
   violation becomes `CategoryNotFoundError` (`kind: not-found`), each chaining
   the original error as `Error.cause`. Application and domain code therefore
@@ -150,8 +151,8 @@ context, it stays inside that context.
 
 **8. Cross-context capabilities are exposed via published ports**
 A bounded context that needs to be **consumed** by other contexts (e.g.
-`audit`) publishes a port — a TypeScript `interface` plus a `Symbol` DI
-token — in its `application/ports/` folder, and binds the token to its
+`audit`) publishes a port - a TypeScript `interface` plus a `Symbol` DI
+token - in its `application/ports/` folder, and binds the token to its
 implementation in its NestJS module's `providers` / `exports`. Consumers
 inject the token and depend on the interface only; they never import
 entities or repositories from another context's `domain/`. This is the
@@ -163,13 +164,13 @@ payment use cases need to log audit entries.
 **9. Path aliases for cross-boundary imports**
 Imports that cross a context boundary use TypeScript path aliases:
 
-- `@shared/*` → `src/shared/*`
-- `@modules/*` → `src/modules/*`
+- `@shared/*` -> `src/shared/*`
+- `@modules/*` -> `src/modules/*`
 
 Imports **inside** the same bounded context stay relative
 (`../domain/entities/product.entity`). The alias is a visual signal that
 the import crosses a context boundary; a relative path documents that the
-dependency stays local. This is a convention, not a lint rule — review for
+dependency stays local. This is a convention, not a lint rule - review for
 it in PRs.
 
 > When adding a new alias, **four** configs must stay in sync:
@@ -183,10 +184,10 @@ it in PRs.
 > `jsc.baseUrl` (so `shared/*` with baseUrl `./src`); jest paths use
 > jest's `<rootDir>` token.
 
-**10. Build pipeline — SWC with `tsc` type-check sidecar**
+**10. Build pipeline - SWC with `tsc` type-check sidecar**
 `nest build` uses [SWC](https://swc.rs/) (configured in `nest-cli.json`
 under `compilerOptions.builder`) instead of `tsc`. SWC compiles each file
-in parallel — roughly 10× faster on this codebase — and resolves path
+in parallel - roughly 10x faster on this codebase - and resolves path
 aliases natively, so `dist/` contains real relative paths and no runtime
 alias resolver is needed.
 
@@ -195,21 +196,21 @@ that file minimal: it declares only `jsc.baseUrl` and `jsc.paths` so SWC
 has its own source of truth for alias resolution and does not try to
 recombine the tsconfig values. The decorator and `emitDecoratorMetadata`
 behavior NestJS needs comes from the defaults that the `@nestjs/cli`
-SWC integration injects — replicating them in `.swcrc` would just be
+SWC integration injects - replicating them in `.swcrc` would just be
 duplication.
 
 SWC does not perform type checking. The `typeCheck: true` flag in
 `nest-cli.json` runs `tsc --noEmit` alongside the SWC compile so type
 errors still fail the build.
 
-> ⚠️ **Caveat — circular imports + SWC.** Because SWC compiles each file
+> **Caveat - circular imports + SWC.** Because SWC compiles each file
 > in isolation, it can mis-emit `design:type` reflection metadata when two
 > files reference each other across a decorator boundary (`@Injectable()`,
 > `class-validator`, decorator-driven ORMs). The build succeeds; the bug
 > surfaces only at runtime (DI injects `undefined`, validator silently
 > skipped, ORM loses the relation).
 >
-> **Low risk for this project today** — Prisma does not rely on
+> **Low risk for this project today** - Prisma does not rely on
 > `emitDecoratorMetadata` and domain entities are plain classes.
 > `class-validator` is now wired (global `ValidationPipe` + `SignInDto`),
 > but its DTOs are flat (no bidirectional aggregate references), so the
@@ -220,7 +221,7 @@ errors still fail the build.
 > - Adopting a decorator-based ORM with bidirectional relations
 >
 > Mitigations, in preferred order: (1) use `import type` for type-only
-> imports — they are erased at runtime and break many cycles automatically;
+> imports - they are erased at runtime and break many cycles automatically;
 > (2) treat circularity as a design smell and refactor; (3) `forwardRef()`
 > for module-level DI cycles; (4) for metadata-driven cases without ORM
 > workarounds, define a wrapper type analogous to TypeORM's `Relation<T>`
@@ -237,7 +238,7 @@ src/
 ├── shared/                       ← Cross-context kernel
 │   ├── auth/                     ← Global AuthGuard, @Public/@Roles, JWT payload
 │   ├── errors/                   ← DomainError/ApplicationError base + ErrorKind
-│   ├── filter/                   ← Global exception filter (error → envelope)
+│   ├── filter/                   ← Global exception filter (error -> envelope)
 │   ├── infrastructure/
 │   │   └── prisma/               ← @Global() PrismaService + lifecycle
 │   └── pagination/               ← Cursor-pagination types and DTO envelope
@@ -266,11 +267,16 @@ src/
     │   ├── domain/               ← User entity, repo + hasher/signer ports, UserRole
     │   ├── application/          ← SignInUseCase + app-layer errors
     │   └── infrastructure/       ← Argon2 hasher, JWT signer, auth controller/DTO
-    └── orders/                   ← Channel-aware order creation
-        ├── orders.module.ts
-        ├── domain/               ← Order/OrderItem entities, OrderChannel/Status VOs (channel policies), OrderRepository, NOT_FOUND errors
-        ├── application/          ← CreateOrderUseCase + AttendantRequiredError
-        └── infrastructure/       ← PrismaOrderRepository, OrdersController, request/response DTOs
+    ├── orders/                   ← Channel-aware order creation
+    │   ├── orders.module.ts
+    │   ├── domain/               ← Order/OrderItem entities, OrderChannel/Status VOs (channel policies), OrderRepository, NOT_FOUND errors
+    │   ├── application/          ← Use cases + OrderForPayment port (published to payments) + errors
+    │   └── infrastructure/       ← PrismaOrderRepository, OrdersController, request/response DTOs
+    └── payments/                 ← Gateway charge + webhook confirmation
+        ├── payments.module.ts
+        ├── domain/               ← Payment entity, PaymentStatus/PaymentMethod VOs, PaymentRepository
+        ├── application/          ← CreatePayment/ConfirmPayment/FindPaymentByOrder, PaymentGateway port, errors
+        └── infrastructure/       ← MockPaymentGateway, PrismaPaymentRepository, PaymentsController, webhook guard, DTOs
 prisma/
 ├── schema.prisma                 ← Single source of truth for the database
 ├── seed.ts                       ← Idempotent seed for local dev
@@ -282,8 +288,8 @@ test/
 └── global-error-filter.e2e-spec.ts ← Error envelope e2e (full pipeline)
 ```
 
-> Remaining contexts (`inventory`, `orders`, `payments`, `promotions`,
-> `loyalty`) will follow the same internal shape under `src/modules/`.
+> Remaining contexts (`inventory`, `promotions`, `loyalty`) will follow the
+> same internal shape under `src/modules/`.
 
 ---
 
@@ -322,11 +328,11 @@ PORT=3000
 JWT_SECRET_KEY=replace-with-a-strong-random-secret
 ```
 
-> ⚠️ `DATABASE_URL` uses `localhost` for local development. The full-stack
+> `DATABASE_URL` uses `localhost` for local development. The full-stack
 > Docker compose (`docker-compose.prod.yml`) overrides this variable inside
 > the `app` service so it points at the `db` service hostname.
 >
-> 🔑 `JWT_SECRET_KEY` is **required** — the identity module calls
+> `JWT_SECRET_KEY` is **required** - the identity module calls
 > `cfg.getOrThrow('JWT_SECRET_KEY')` on boot and the app exits if it is
 > missing. Generate one with, for example:
 >
@@ -353,7 +359,7 @@ npm run db:seed      # loads sample data
 
 You have two options.
 
-**Option A — Local watch mode (recommended for development):**
+**Option A - Local watch mode (recommended for development):**
 
 ```bash
 npm run start:dev
@@ -361,10 +367,10 @@ npm run start:dev
 
 This expects the database to be already up (step 4). The API is then
 available at **http://localhost:3000/api**. Swagger UI is exposed at
-**http://localhost:3000/api/docs** (development only — disabled when
+**http://localhost:3000/api/docs** (development only - disabled when
 `NODE_ENV=production`).
 
-**Option B — Full Docker stack (build the image, run migrations + seed via
+**Option B - Full Docker stack (build the image, run migrations + seed via
 the container entrypoint):**
 
 ```bash
@@ -377,7 +383,7 @@ On startup, the application container automatically:
 2. Runs the database seed (`prisma db seed`)
 3. Starts the compiled NestJS server on port `3000`
 
-> ℹ️ The default `docker-compose.yml` only contains the `db` service — it is
+> The default `docker-compose.yml` only contains the `db` service - it is
 > the file used by `npm run db:up`. The `app` service lives in
 > `docker-compose.prod.yml`, so the full stack requires the explicit `-f`
 > flag.
@@ -401,7 +407,7 @@ re-applies migrations, re-seeds and starts the watcher:
 npm run devs
 ```
 
-> ⚠️ `npm run devs` runs `db:down -v`, which **wipes the local database
+> `npm run devs` runs `db:down -v`, which **wipes the local database
 > volume**. Never run it against any environment that holds data you care
 > about.
 
@@ -438,29 +444,29 @@ npm run devs
 > Of the domains above, **Identity, Business Units, Audit and Orders**
 > (creation only) have application code shipped. The remaining tables
 > (Inventory, Payments, Promotions, Loyalty) exist in the schema as
-> forward-looking infrastructure — there are no use cases, controllers or
+> forward-looking infrastructure - there are no use cases, controllers or
 > repositories for them yet.
 
 ### Design Decisions
 
-- **UUIDs as primary keys** — prevents sequential ID exposure and
+- **UUIDs as primary keys** - prevents sequential ID exposure and
   enumeration attacks; safer for distributed systems.
-- **camelCase in TypeScript, snake_case in PostgreSQL** — enforced via
+- **camelCase in TypeScript, snake_case in PostgreSQL** - enforced via
   `@map()` and `@@map()` directives so each side follows its own idiomatic
   convention.
-- **`Decimal(10, 2)` for monetary values** — avoids floating-point precision
+- **`Decimal(10, 2)` for monetary values** - avoids floating-point precision
   loss on multiplication and rounding.
-- **`DateTime` (TIMESTAMPTZ) for `createdAt`/`updatedAt`** — preserves
+- **`DateTime` (TIMESTAMPTZ) for `createdAt`/`updatedAt`** - preserves
   timezone semantics, is human-readable in queries, and Prisma serializes
   it as ISO-8601 to JSON. Numeric Unix timestamps were intentionally
   rejected because they lose precision and timezone meaning.
-- **Optional descriptions are `NULL`, not empty strings** — `NULL`
+- **Optional descriptions are `NULL`, not empty strings** - `NULL`
   unambiguously means "no value" and is semantically distinct from an empty
   description, which is a meaningful (but unusual) state.
-- **Selective audit trail** — `updated_by` is applied only where
+- **Selective audit trail** - `updated_by` is applied only where
   operationally or legally relevant (e.g. LGPD compliance), avoiding
   pointless metadata noise on append-only tables.
-- **Indexed columns by access pattern** — every foreign key and every
+- **Indexed columns by access pattern** - every foreign key and every
   enum-style filter (`isActive`, `orderStatus`, etc.) has an explicit
   `@@index`.
 
@@ -475,8 +481,8 @@ All routes are prefixed with **`/api`**.
 When `NODE_ENV` is not `production`, an OpenAPI document and Swagger UI are
 exposed at:
 
-- UI — **http://localhost:3000/api/docs**
-- JSON — **http://localhost:3000/api/docs-json**
+- UI - **http://localhost:3000/api/docs**
+- JSON - **http://localhost:3000/api/docs-json**
 
 Swagger is disabled in production to avoid leaking schema details. Bearer
 auth is wired into the document (`addBearerAuth`) so you can paste a JWT
@@ -486,7 +492,7 @@ returned by `POST /api/auth/login` directly into the "Authorize" dialog.
 
 A global `AuthGuard` protects every route by default; routes opt out with
 `@Public()`. The read endpoints shipped so far are public; **writes are
-protected** — `POST /api/products` requires a `Bearer` JWT in the
+protected** - `POST /api/products` requires a `Bearer` JWT in the
 `Authorization` header and the `ADMIN` or `MANAGER` role (via `@Roles()`).
 `POST /api/orders` also requires a Bearer JWT, but the required role is not
 fixed on the route: it is enforced per request by the `orderChannel` policy
@@ -497,13 +503,13 @@ missing or invalid and `403` when the role is insufficient.
 | ------ | ----------------- | ------ | ------------------------------------------- |
 | `POST` | `/api/auth/login` | Public | Exchange `username` + `password` for a JWT. |
 
-Request body — `SignInDto` (`password` ≥ 8 chars):
+Request body - `SignInDto` (`password` >= 8 chars):
 
 ```json
 { "username": "jane", "password": "min-8-chars" }
 ```
 
-Response — `200 OK`:
+Response - `200 OK`:
 
 ```json
 { "access_token": "eyJhbGciOiJI..." }
@@ -511,7 +517,7 @@ Response — `200 OK`:
 
 Invalid credentials return `401` (see [Error responses](#error-responses)).
 
-Every login attempt — successful **and** failed — is persisted to the
+Every login attempt - successful **and** failed - is persisted to the
 `audit_logs` table by the `AuditService` (`LOGIN_SUCCESS` or `LOGIN_FAILED`
 action). Metadata is defensively sanitized: any key matching
 `password` / `token` / `cpf` / `authorization` / `secret` (case-insensitive,
@@ -527,7 +533,7 @@ swallowed so they cannot break the login outcome.
 | `GET`  | `/api/products/by-business-unit/:businessUnitId` | Public          | List products available at a business unit (effective price = `customPrice` when set, otherwise `basePrice`). |
 | `POST` | `/api/products`                                  | ADMIN / MANAGER | Create a product. `201` on success, `409` if the name exists, `404` if the category does not exist.           |
 
-#### Request body — `ProductCreateDto` (`POST /api/products`)
+#### Request body - `ProductCreateDto` (`POST /api/products`)
 
 `price` is a **positive decimal string** (up to 8 integer + 2 fractional
 digits, matching the `Decimal(10, 2)` column); `imageUrl` must be a valid URL;
@@ -543,7 +549,7 @@ digits, matching the `Decimal(10, 2)` column); `imageUrl` must be a valid URL;
 }
 ```
 
-#### Response — `ProductResponseDto`
+#### Response - `ProductResponseDto`
 
 ```json
 {
@@ -577,19 +583,19 @@ digits, matching the `Decimal(10, 2)` column); `imageUrl` must be a valid URL;
 
 When the channel requires a staff actor (`COUNTER` / `PICKUP`), a JWT
 belonging to a `CUSTOMER` is rejected with `403 AttendantRequiredError`.
-For these channels `attendantId` is taken from the JWT (`sub`) — never from
+For these channels `attendantId` is taken from the JWT (`sub`) - never from
 the request body.
 
-#### Request body — `OrderCreateDto`
+#### Request body - `OrderCreateDto`
 
-`unitPrice` is a **decimal string** (`@IsDecimal`, up to 2 fractional digits) —
+`unitPrice` is a **decimal string** (`@IsDecimal`, up to 2 fractional digits) -
 money is never coerced to a `number`. `totalAmount` is **not** accepted from
-the client: it is computed server-side from each item's `quantity × unitPrice`
+the client: it is computed server-side from each item's `quantity x unitPrice`
 via domain statics (`OrderItem.calculateSubtotal`, `Order.calculateTotalAmount`).
 
 `unitPrice` is also **validated server-side** against the authoritative price
 of the product at the business unit. Resolution order is
-`BusinessUnitMenuItem.customPrice` (when a menu item exists for the pair) →
+`BusinessUnitMenuItem.customPrice` (when a menu item exists for the pair) ->
 `Product.basePrice`. A divergence surfaces as `422 PriceMismatchError`, so a
 tampered body cannot buy an item for a price different from the registered
 one. The same lookup also surfaces `Product.isActive`: an order referencing
@@ -616,7 +622,7 @@ points (1 point per real). Until then every order persists `pointsEarned = 0`
 }
 ```
 
-#### Response — `OrderResponseDto`
+#### Response - `OrderResponseDto`
 
 Money fields (`totalAmount`, `unitPrice`, `subtotal`) are serialized as a
 **decimal string** so JSON cannot reintroduce float rounding on the client.
@@ -650,11 +656,87 @@ Money fields (`totalAmount`, `unitPrice`, `subtotal`) are serialized as a
 ```
 
 A foreign key pointing to a missing business unit, customer, attendant or
-product surfaces as `404 OrderReferenceNotFoundError` — `PrismaOrderRepository`
+product surfaces as `404 OrderReferenceNotFoundError` - `PrismaOrderRepository`
 translates Prisma's `P2003` into a typed domain error and inspects
 `err.meta.field_name` to produce a message that names the specific reference
 (`customer`, `business unit`, `product`, `attendant`) instead of grouping all
 foreign-key failures under one generic label.
+
+### Payments
+
+| Method | Path                           | Auth           | Description                                                    |
+| ------ | ------------------------------ | -------------- | -------------------------------------------------------------- |
+| `POST` | `/api/payments`                | Bearer         | Create a payment for an order and charge the gateway.          |
+| `POST` | `/api/payments/webhook`        | Webhook secret | Gateway callback: settle a payment and advance its order.      |
+| `GET`  | `/api/orders/:orderId/payment` | Bearer         | Get the payment of an order. Customers may only see their own. |
+
+#### The webhook is the source of truth
+
+Payment confirmation follows the asynchronous-gateway model used in production
+processors (Stripe, Mercado Pago): `POST /api/payments` charges the gateway and
+persists the payment as **`PROCESSING`**, but the order is **not** advanced yet.
+The gateway then calls back `POST /api/payments/webhook`, and only that callback
+settles the payment to `APPROVED`/`REFUSED`. On approval the order is advanced to
+`CONFIRMED` **in the same database transaction** as the payment update, so the two
+never drift apart. The webhook is idempotent: a redelivered callback for an
+already-settled payment is a no-op.
+
+> **Cross-context note.** Payments never imports the `Order` entity. The orders
+> context publishes an `OrderForPayment` port (a TypeScript interface + `Symbol`
+> token, the same mechanism as `AUDIT_LOGGER`) exposing only what payments needs:
+> read the order's payable state/total, and confirm it after approval. The order
+> confirmation reuses the existing order state machine and optimistic lock.
+
+#### Request body - `CreatePaymentDto` (`POST /api/payments`)
+
+`amount` is **not** accepted from the client: it is the order's authoritative
+`totalAmount`, read server-side (anti-tampering, mirroring `unitPrice` on orders).
+An order that is not `PENDING`, or that already has a payment, is rejected with
+`422 OrderNotPayableError` (the `payments.order_id` unique constraint also guards
+the concurrent double-payment race).
+
+```json
+{ "orderId": "7c9e6679-7425-40de-944b-e07fc1f90ae7", "method": "PIX" }
+```
+
+#### Request body - `PaymentWebhookDto` (`POST /api/payments/webhook`)
+
+The request must carry the shared secret in the **`x-webhook-secret`** header
+(stand-in for gateway signature verification); a missing/invalid secret returns
+`401`. `status` is the settled outcome the gateway reports.
+
+```json
+{ "extTransactionId": "mock_4f1c...", "status": "APPROVED" }
+```
+
+#### Response - `PaymentResponseDto`
+
+`amount` is serialized as a **decimal string** so JSON cannot reintroduce float
+rounding on the client.
+
+```json
+{
+  "id": "9b2e...",
+  "orderId": "7c9e...",
+  "amount": "25.00",
+  "method": "PIX",
+  "status": "PROCESSING",
+  "extTransactionId": "mock_4f1c...",
+  "createdAt": "2026-05-31T12:00:00.000Z",
+  "updatedAt": "2026-05-31T12:00:00.000Z"
+}
+```
+
+> **Mock gateway.** The bundled `MockPaymentGateway` simulates ~200 ms of latency
+> and **refuses any charge of exactly `13.13`**, approving everything else - a
+> deterministic hook for exercising the failure path in tests.
+
+> **Note on order status (idiomatic deviation).** The sprint brief described the
+> post-payment state as `EM_PREPARO` ("preparing"). The codebase is English-only
+> and an approved payment advances the order to **`CONFIRMED`**: a payment
+> _confirms_ an order, while `PREPARING` stays the kitchen's explicit human
+> acceptance. `PENDING -> CONFIRMED` was already a valid transition, so the state
+> machine was not changed.
 
 ### Error responses
 
@@ -672,23 +754,23 @@ are logged server-side but never sent to the client:
 }
 ```
 
-| Status | When                                                                                       |
-| ------ | ------------------------------------------------------------------------------------------ |
-| `400`  | Request body fails validation (`class-validator` + `ValidationPipe`)                       |
-| `401`  | Invalid login credentials, or missing/invalid JWT on a protected route                     |
-| `403`  | Authenticated but the role is not allowed (e.g. a `CUSTOMER` creating a `COUNTER` order)   |
-| `404`  | Requested product does not exist, or an order references a missing business unit / product |
-| `409`  | A product with the same name already exists (`ProductAlreadyExistsError`)                  |
-| `422`  | An order references an inactive product (`ProductInactiveError`) or a `unitPrice` does not match the authoritative price (`PriceMismatchError`) |
-| `503`  | Repository / database failure (`ProductsFetchError`)                                       |
+| Status | When                                                                                                                  |
+| ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `400`  | Request body fails validation (`class-validator` + `ValidationPipe`)                                                  |
+| `401`  | Invalid login credentials, missing/invalid JWT, or a webhook with a missing/invalid secret                            |
+| `403`  | Authenticated but the role is not allowed (e.g. a `CUSTOMER` creating a `COUNTER` order)                              |
+| `404`  | Requested product/order/payment does not exist, or an order references a missing reference                            |
+| `409`  | A product with the same name already exists (`ProductAlreadyExistsError`)                                             |
+| `422`  | An order references an inactive product / mismatched `unitPrice`, or an order is not payable (`OrderNotPayableError`) |
+| `503`  | Repository / database failure (`ProductsFetchError`)                                                                  |
 
 Application and domain errors carry a transport-agnostic `kind` that the filter
-maps to a status: `not-found` → 404, `invalid` → 422, `conflict` → 409,
-`unauthorized` → 401, `forbidden` → 403, `unavailable` → 503. Use cases throw
+maps to a status: `not-found` -> 404, `invalid` -> 422, `conflict` -> 409,
+`unauthorized` -> 401, `forbidden` -> 403, `unavailable` -> 503. Use cases throw
 these (e.g. `ProductNotFoundError`, `InvalidCredentialsError`) instead of HTTP
 exceptions, keeping the application layer framework-agnostic. NestJS
-`HttpException`s raised by the framework itself — the `AuthGuard` (`401`/`403`)
-and the validation pipe (`400`) — keep their own status and are re-wrapped into
+`HttpException`s raised by the framework itself - the `AuthGuard` (`401`/`403`)
+and the validation pipe (`400`) - keep their own status and are re-wrapped into
 the same envelope.
 
 ---
@@ -702,7 +784,7 @@ npm test
 # Watch mode
 npm run test:watch
 
-# Coverage report → ./coverage/lcov-report/index.html
+# Coverage report -> ./coverage/lcov-report/index.html
 npm run test:cov
 
 # End-to-end tests (boots the full Nest application)
@@ -716,12 +798,12 @@ npm run test:e2e
   `AuthGuard` are validated without any database. Entities, value objects,
   DTOs and the global exception filter are tested in isolation.
 - **e2e tests** boot the full Nest application against the development
-  database and exercise the HTTP surface — products
+  database and exercise the HTTP surface - products
   (`app.e2e-spec.ts`), login + audit-log persistence
   (`auth-audit.e2e-spec.ts`), global validation rejection
   (`validation-pipe.e2e-spec.ts`), and the global error envelope via a
   throwing repository (`global-error-filter.e2e-spec.ts`).
-- Each test asserts both **success paths** and **failure paths** — including
+- Each test asserts both **success paths** and **failure paths** - including
   `ProductNotFoundError` propagation, domain errors surfacing from the create
   use case (`ProductAlreadyExistsError`), and `ProductsFetchError` wrapping
   with `Error.cause`.
@@ -733,11 +815,11 @@ npm run test:e2e
 - **ESLint** (`eslint.config.mjs`) with `typescript-eslint` strict-typed
   rules, `no-explicit-any: error`, `no-floating-promises: error`,
   `eqeqeq: error`, `curly: error`.
-- **Prettier** (`.prettierrc`) — single quotes, 100-column width,
+- **Prettier** (`.prettierrc`) - single quotes, 100-column width,
   trailing commas everywhere.
-- **Husky + lint-staged** — pre-commit hook runs ESLint and Prettier on
+- **Husky + lint-staged** - pre-commit hook runs ESLint and Prettier on
   staged TypeScript files only.
-- **GitHub Actions CI** (`.github/workflows/ci.yml`) — installs
+- **GitHub Actions CI** (`.github/workflows/ci.yml`) - installs
   dependencies, generates the Prisma client, lints, tests and builds on
   every push to `main`/`develop` and on every PR to `main`.
 
@@ -746,26 +828,26 @@ npm run test:e2e
 ## Roadmap
 
 The product catalog, identity and audit modules are shipped. Upcoming
-modules — already designed in the database schema — are:
+modules - already designed in the database schema - are:
 
-- [x] **Auth** — JWT login, global role guard, argon2 hashing (`CUSTOMER`,
+- [x] **Auth** - JWT login, global role guard, argon2 hashing (`CUSTOMER`,
       `ATTENDANT`, `KITCHEN`, `MANAGER`, `ADMIN`). Refresh-token rotation
       and user registration still pending.
-- [x] **Audit** — `audit_logs` table, `AuditService` with metadata
+- [x] **Audit** - `audit_logs` table, `AuditService` with metadata
       sanitization (password/token/CPF redaction), `AuditLogger` port
       injected into `SignInUseCase` for `LOGIN_SUCCESS` / `LOGIN_FAILED`.
       Ready to be injected into future order / payment use cases.
-- [x] **Orders** — channel-aware `POST /api/orders` with decimal-string
+- [x] **Orders** - channel-aware `POST /api/orders` with decimal-string
       money, server-side total, server-side `unitPrice` validation against
       `BusinessUnitMenuItem.customPrice` / `Product.basePrice` (anti-tampering),
       `Product.isActive` enforcement (inactive products cannot be ordered),
       attendant role check via `OrderChannel` policies, and `customerId`
       nullable for anonymous totem orders. Item updates, status transitions,
       idempotent creation and order reads still pending.
-- [ ] **Payments** — gateway integration (mocked initially), refund flow
-- [ ] **Inventory** — stock, reservations, inventory transactions ledger
-- [ ] **Promotions** — percentage / fixed-amount / free-item discounts
-- [ ] **Loyalty** — points earning (`floor(totalAmount)` per order, conditional
+- [ ] **Payments** - gateway integration (mocked initially), refund flow
+- [ ] **Inventory** - stock, reservations, inventory transactions ledger
+- [ ] **Promotions** - percentage / fixed-amount / free-item discounts
+- [ ] **Loyalty** - points earning (`floor(totalAmount)` per order, conditional
       on a `LoyaltyAccount` with `consentGiven=true`), redemption with balance
       validation against `LoyaltyAccount.totalPoints`, and consent tracking
       (LGPD). The `pointsEarned` hook lives in `CreateOrderUseCase` already.
@@ -774,4 +856,4 @@ modules — already designed in the database schema — are:
 
 ## License
 
-Academic project — all rights reserved.
+Academic project - all rights reserved.

--- a/prisma/migrations/20260531180000_payments_attempt_model/migration.sql
+++ b/prisma/migrations/20260531180000_payments_attempt_model/migration.sql
@@ -1,0 +1,20 @@
+-- A Payment becomes one *attempt*: an order may have many attempts, at most one
+-- live/settled at a time. This replaces "one payment per order" with a retriable model.
+
+-- Drop the old "one payment per order" unique constraint.
+DROP INDEX "payments_order_id_key";
+
+-- Plain lookup index on order_id (replaces the dropped unique).
+CREATE INDEX "payments_order_id_idx" ON "payments"("order_id");
+
+-- ext_transaction_id is now unique (matches @unique in schema; lets us use findUnique).
+-- NULLs are distinct in Postgres, so reserved-but-not-yet-charged rows are unaffected.
+CREATE UNIQUE INDEX "payments_ext_transaction_id_key" ON "payments"("ext_transaction_id");
+
+-- At most one *live* attempt per order. This partial unique index is the single
+-- concurrency guard: a second concurrent create (or one while a payment is in
+-- flight/approved) fails with P2002 *before* the gateway is charged. REFUSED/CANCELLED
+-- do not occupy the slot, so a refused order can be paid again.
+CREATE UNIQUE INDEX "payments_order_id_active_key"
+  ON "payments"("order_id")
+  WHERE "status" IN ('PENDING', 'PROCESSING', 'APPROVED');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -275,12 +275,12 @@ enum PaymentStatus {
 
 model Payment {
   id      String @id @default(uuid())
-  orderId String @unique @map("order_id")
+  orderId String @map("order_id")
 
   amount           Decimal       @db.Decimal(10, 2)
   method           PaymentMethod
   status           PaymentStatus @default(PENDING)
-  extTransactionId String?       @map("ext_transaction_id")
+  extTransactionId String?       @unique @map("ext_transaction_id")
   gatewayRequest   Json?         @map("gateway_request")
   gatewayResponse  Json?         @map("gateway_response")
   createdAt        DateTime      @default(now()) @map("created_at")
@@ -288,6 +288,10 @@ model Payment {
 
   order Order @relation(fields: [orderId], references: [id])
 
+  // A payment is one *attempt*: an order may have many, at most one live/settled.
+  // The "one live attempt per order" rule is a partial unique index added in the
+  // migration SQL (Prisma can't express a filtered index in the schema).
+  @@index([orderId])
   @@index([status])
   @@map("payments")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthGuard } from '@shared/auth/auth.guard';
 import { GlobalErrorFilter } from '@shared/filter/global-error.filter';
 import { AuditModule } from '@modules/audit/audit.module';
 import { OrdersModule } from '@modules/orders/orders.module';
+import { PaymentsModule } from '@modules/payments/payments.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { OrdersModule } from '@modules/orders/orders.module';
     IdentityModule,
     BusinessUnitsModule,
     OrdersModule,
+    PaymentsModule,
   ],
   providers: [
     {

--- a/src/modules/audit/application/ports/audit-logger.port.ts
+++ b/src/modules/audit/application/ports/audit-logger.port.ts
@@ -3,6 +3,11 @@ import { AuditLogRecord } from '@modules/audit/domain/repositories/audit-log.rep
 export type AuditLogInput = AuditLogRecord;
 
 export interface AuditLogger {
+  /**
+   * Records an audit entry. Best-effort by contract: it never throws on a persistence
+   * failure (the implementation logs and swallows), so callers can `await` it without a
+   * guard and a broken audit write never fails or rolls back the business operation.
+   */
   log(input: AuditLogInput): Promise<void>;
 }
 

--- a/src/modules/audit/domain/audit-actions.ts
+++ b/src/modules/audit/domain/audit-actions.ts
@@ -3,6 +3,11 @@ export const AUDIT_ACTIONS = {
   LOGIN_FAILED: 'LOGIN_FAILED',
   ORDER_CREATED: 'ORDER_CREATED',
   ORDER_STATUS_CHANGED: 'ORDER_STATUS_CHANGED',
+  PAYMENT_CREATED: 'PAYMENT_CREATED',
+  PAYMENT_APPROVED: 'PAYMENT_APPROVED',
+  PAYMENT_REFUSED: 'PAYMENT_REFUSED',
+  /** Payment approved but the order could not be confirmed - needs manual reconciliation. */
+  PAYMENT_RECONCILE_REQUIRED: 'PAYMENT_RECONCILE_REQUIRED',
 } as const;
 
 export type AuditAction = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];

--- a/src/modules/business-units/infrastructure/http/dto/paginated-product-response.dto.ts
+++ b/src/modules/business-units/infrastructure/http/dto/paginated-product-response.dto.ts
@@ -5,7 +5,7 @@ import { ProductResponseDto } from './product-response.dto';
 /**
  * Schema-only DTO: never instantiated at runtime. It exists so Swagger can
  * describe the generic `PaginatedResponseDto<ProductResponseDto>` returned by
- * the list endpoints (OpenAPI has no generics — a concrete class is needed).
+ * the list endpoints (OpenAPI has no generics - a concrete class is needed).
  */
 export class PaginatedProductResponseDto {
   @ApiProperty({ type: [ProductResponseDto] })

--- a/src/modules/business-units/infrastructure/persistence/prisma-product.repository.spec.ts
+++ b/src/modules/business-units/infrastructure/persistence/prisma-product.repository.spec.ts
@@ -57,7 +57,7 @@ describe('PrismaProductRepository', () => {
 
       const product = await repo.create(input);
 
-      // Money is forwarded as the original decimal string — never coerced to a float.
+      // Money is forwarded as the original decimal string - never coerced to a float.
       expect(create).toHaveBeenCalledWith({
         data: {
           name: input.name,

--- a/src/modules/identity/application/use-cases/sign-in.use-case.ts
+++ b/src/modules/identity/application/use-cases/sign-in.use-case.ts
@@ -69,7 +69,7 @@ export class SignInUseCase {
     return { access_token: token };
   }
 
-  // Defense-in-depth: audit must never break the login outcome, regardless of impl.
+  // Audit must never break the login outcome, so failures here are swallowed.
   private async tryAudit(input: AuditLogInput): Promise<void> {
     try {
       await this.auditLogger.log(input);

--- a/src/modules/orders/application/ports/order-for-payment.port.ts
+++ b/src/modules/orders/application/ports/order-for-payment.port.ts
@@ -1,0 +1,35 @@
+import type { TransactionContext } from '@shared/transaction/transaction-runner.port';
+
+export const ORDER_FOR_PAYMENT = Symbol('OrderForPayment');
+
+/** The slice of an order the payments context needs - never the Order entity itself. */
+export interface OrderForPaymentView {
+  id: string;
+  /** True when the order is still PENDING and may be paid. Keeps the orders status taxonomy out of payments. */
+  isAwaitingPayment: boolean;
+  /** Authoritative amount to charge, as a decimal string (money is never a JS number). */
+  totalAmount: string;
+  customerId: string | null;
+}
+
+/**
+ * Result of trying to confirm an order after an approved payment. `not_confirmed` means
+ * the order had already moved on (cancelled/deleted): the payment still settles and the
+ * caller records the mismatch for reconciliation instead of rolling the money back.
+ */
+export type OrderConfirmOutcome = 'confirmed' | 'not_confirmed';
+
+/**
+ * Capability published by the orders context for the payments context to consume.
+ * Payments depends on this interface only; it never imports the Order entity or
+ * repository, keeping the cross-context coupling to a single published port.
+ */
+export interface OrderForPayment {
+  findForPayment(orderId: string): Promise<OrderForPaymentView | null>;
+  /**
+   * Advances the order to CONFIRMED after an approved payment. Reuses the order state
+   * machine and optimistic lock; pass the caller's `tx` so the order write shares the
+   * payment's transaction. Never throws on a lost optimistic lock - returns the outcome.
+   */
+  confirmAfterPayment(orderId: string, tx?: TransactionContext): Promise<OrderConfirmOutcome>;
+}

--- a/src/modules/orders/application/ports/order-product-lookup.port.ts
+++ b/src/modules/orders/application/ports/order-product-lookup.port.ts
@@ -6,9 +6,9 @@ export const ORDER_PRODUCT_LOOKUP = Symbol('OrderProductLookup');
 export interface ResolvedProduct {
   /** Authoritative price for the product at the business unit: BusinessUnitMenuItem.customPrice. */
   price: Big;
-  /** Product.isActive — whether the product is enabled brand-wide. */
+  /** Product.isActive - whether the product is enabled brand-wide. */
   isActive: boolean;
-  /** BusinessUnitMenuItem.isAvailable — whether the unit is currently offering it. */
+  /** BusinessUnitMenuItem.isAvailable - whether the unit is currently offering it. */
   isAvailable: boolean;
 }
 

--- a/src/modules/orders/application/services/order-for-payment.service.spec.ts
+++ b/src/modules/orders/application/services/order-for-payment.service.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
+import { OrderForPaymentService } from './order-for-payment.service';
+import type { OrderRepository } from '../../domain/repositories/order.repository';
+import type { UpdateOrderStatusUseCase } from '../use-cases/update-order-status.use-case';
+import { Order } from '../../domain/entities/order.entity';
+import { OrderItem } from '../../domain/entities/order-item.entity';
+import { OrderChannel } from '../../domain/value-objects/order-channel';
+import { OrderStatus } from '../../domain/value-objects/order-status';
+import { InvalidOrderStatusTransitionError } from '../../domain/errors/invalid-order-status-transition.error';
+import { OrderNotFoundError } from '../errors/order-not-found.error';
+import { OrderStatusConflictError } from '../errors/order-status-conflict.error';
+
+const makeOrder = (status: OrderStatus, customerId: string | null = 'c-1'): Order =>
+  new Order(
+    'o-1',
+    'bu-1',
+    customerId,
+    null,
+    0,
+    0,
+    new Big('25'),
+    null,
+    OrderChannel.APP,
+    status,
+    new Date(),
+    new Date(),
+    null,
+    [new OrderItem('i-1', 'o-1', 'p-1', 1, new Big('25'), null)],
+  );
+
+describe('OrderForPaymentService', () => {
+  let findById: jest.MockedFunction<OrderRepository['findById']>;
+  let execute: jest.MockedFunction<UpdateOrderStatusUseCase['execute']>;
+  let service: OrderForPaymentService;
+
+  beforeEach(() => {
+    findById = jest.fn() as jest.MockedFunction<OrderRepository['findById']>;
+    execute = jest.fn() as jest.MockedFunction<UpdateOrderStatusUseCase['execute']>;
+
+    const orders = {
+      create: jest.fn(),
+      findById,
+      findMany: jest.fn(),
+      updateStatus: jest.fn(),
+    } as unknown as OrderRepository;
+    const updateOrderStatus = { execute } as unknown as UpdateOrderStatusUseCase;
+
+    service = new OrderForPaymentService(orders, updateOrderStatus);
+  });
+
+  describe('findForPayment', () => {
+    it('maps the order to the payment view and marks PENDING orders as awaiting payment', async () => {
+      findById.mockResolvedValue(makeOrder(OrderStatus.PENDING));
+
+      const view = await service.findForPayment('o-1');
+
+      expect(view).toEqual({
+        id: 'o-1',
+        isAwaitingPayment: true,
+        totalAmount: '25.00',
+        customerId: 'c-1',
+      });
+    });
+
+    it('marks a non-PENDING order as not awaiting payment', async () => {
+      findById.mockResolvedValue(makeOrder(OrderStatus.CONFIRMED));
+
+      const view = await service.findForPayment('o-1');
+
+      expect(view?.isAwaitingPayment).toBe(false);
+    });
+
+    it('returns null when the order does not exist', async () => {
+      findById.mockResolvedValue(null);
+
+      await expect(service.findForPayment('missing')).resolves.toBeNull();
+    });
+  });
+
+  describe('confirmAfterPayment', () => {
+    it('confirms the order and reports "confirmed", forwarding the tx and a null actor', async () => {
+      execute.mockResolvedValue(makeOrder(OrderStatus.CONFIRMED));
+      const tx = {} as unknown;
+
+      await expect(service.confirmAfterPayment('o-1', tx)).resolves.toBe('confirmed');
+      expect(execute).toHaveBeenCalledWith(
+        { orderId: 'o-1', orderStatus: OrderStatus.CONFIRMED },
+        null,
+        tx,
+      );
+    });
+
+    it.each([
+      ['InvalidOrderStatusTransitionError', new InvalidOrderStatusTransitionError('past PENDING')],
+      ['OrderStatusConflictError', new OrderStatusConflictError('lost the lock')],
+      ['OrderNotFoundError', new OrderNotFoundError('gone')],
+    ])('reports "not_confirmed" when the order moved on (%s)', async (_label, error) => {
+      execute.mockRejectedValue(error);
+
+      await expect(service.confirmAfterPayment('o-1')).resolves.toBe('not_confirmed');
+    });
+
+    it('rethrows unexpected errors', async () => {
+      const boom = new Error('db down');
+      execute.mockRejectedValue(boom);
+
+      await expect(service.confirmAfterPayment('o-1')).rejects.toBe(boom);
+    });
+  });
+});

--- a/src/modules/orders/application/services/order-for-payment.service.ts
+++ b/src/modules/orders/application/services/order-for-payment.service.ts
@@ -1,0 +1,67 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  ORDER_REPOSITORY,
+  type OrderRepository,
+} from '@modules/orders/domain/repositories/order.repository';
+import { OrderStatus } from '@modules/orders/domain/value-objects/order-status';
+import type { TransactionContext } from '@shared/transaction/transaction-runner.port';
+import { UpdateOrderStatusUseCase } from '../use-cases/update-order-status.use-case';
+import { InvalidOrderStatusTransitionError } from '@modules/orders/domain/errors/invalid-order-status-transition.error';
+import { OrderNotFoundError } from '../errors/order-not-found.error';
+import { OrderStatusConflictError } from '../errors/order-status-conflict.error';
+import type {
+  OrderConfirmOutcome,
+  OrderForPayment,
+  OrderForPaymentView,
+} from '../ports/order-for-payment.port';
+
+@Injectable()
+export class OrderForPaymentService implements OrderForPayment {
+  constructor(
+    @Inject(ORDER_REPOSITORY)
+    private readonly orders: OrderRepository,
+    private readonly updateOrderStatus: UpdateOrderStatusUseCase,
+  ) {}
+
+  async findForPayment(orderId: string): Promise<OrderForPaymentView | null> {
+    const order = await this.orders.findById(orderId);
+    if (!order) {
+      return null;
+    }
+
+    return {
+      id: order.id,
+      isAwaitingPayment: order.orderStatus === OrderStatus.PENDING,
+      totalAmount: order.totalAmount.toFixed(2),
+      customerId: order.customerId,
+    };
+  }
+
+  async confirmAfterPayment(
+    orderId: string,
+    tx?: TransactionContext,
+  ): Promise<OrderConfirmOutcome> {
+    // System-driven transition (no acting user): the optimistic lock still guards it.
+    try {
+      await this.updateOrderStatus.execute(
+        { orderId, orderStatus: OrderStatus.CONFIRMED },
+        null,
+        tx,
+      );
+      return 'confirmed';
+    } catch (err) {
+      // The order moved on between charge and webhook: already past PENDING
+      // (InvalidOrderStatusTransition), lost the lock (Conflict), or gone (NotFound).
+      // Swallow it so the payment settlement is not rolled back; the caller logs it
+      // for reconciliation.
+      if (
+        err instanceof InvalidOrderStatusTransitionError ||
+        err instanceof OrderStatusConflictError ||
+        err instanceof OrderNotFoundError
+      ) {
+        return 'not_confirmed';
+      }
+      throw err;
+    }
+  }
+}

--- a/src/modules/orders/application/use-cases/create-order.use-case.spec.ts
+++ b/src/modules/orders/application/use-cases/create-order.use-case.spec.ts
@@ -39,6 +39,7 @@ describe('CreateOrderUseCase', () => {
     null,
     0,
     0,
+    new Big(0),
     null,
     OrderChannel.APP,
     'PENDING',

--- a/src/modules/orders/application/use-cases/create-order.use-case.ts
+++ b/src/modules/orders/application/use-cases/create-order.use-case.ts
@@ -74,8 +74,8 @@ export class CreateOrderUseCase {
 
     const { attendantId, customerId } = this.resolveParties(command, actor);
 
-    // Validate and persist atomically: the menu/product state read here must not
-    // change before the order insert, so both share one transaction.
+    // Validate and insert in one transaction, so the menu/product state can't change
+    // between the read and the order insert.
     const order = await this.transactions.run(async (tx) => {
       await this.assertOrderableProducts(command, tx);
 
@@ -84,13 +84,16 @@ export class CreateOrderUseCase {
         subtotal: OrderItem.calculateSubtotal(item.quantity, item.unitPrice).toString(),
       }));
 
-      const totalAmount = Order.calculateTotalAmount(
-        orderItems.map((item) => item.subtotal),
-      ).toString();
+      const itemsSubtotal = Order.calculateItemsSubtotal(orderItems.map((item) => item.subtotal));
 
-      // TODO(loyalty): when the loyalty module ships, set pointsEarned = floor(totalAmount)
-      // only if the customer has a LoyaltyAccount with consentGiven=true; otherwise 0.
-      // Today no loyalty data exists, so every order keeps pointsEarned at the DB default (0).
+      // TODO(loyalty): when the loyalty module ships, derive this discount from
+      // pointsRedeemed (points -> money at the loyalty rate) instead of 0. The discount
+      // rule (total = subtotal - discount) already lives in Order.computeTotal.
+      const discountAmount = new Big(0);
+      const totalAmount = Order.computeTotal(itemsSubtotal, discountAmount).toString();
+
+      // TODO(loyalty): also set pointsEarned = floor(totalAmount) only when the customer
+      // has a LoyaltyAccount with consent. For now it stays at the DB default (0).
 
       return this.orders.create(
         {
@@ -123,7 +126,7 @@ export class CreateOrderUseCase {
    * Rejects orders that reference a product not on this unit's menu (404), a product
    * that is inactive brand-wide (422), a menu item currently unavailable (422), or a
    * unitPrice that diverges from the authoritative price (422). Authoritative price is
-   * BusinessUnitMenuItem.customPrice — only menu items are orderable.
+   * BusinessUnitMenuItem.customPrice - only menu items are orderable.
    */
   private async assertOrderableProducts(
     command: CreateOrderCommand,
@@ -180,10 +183,16 @@ export class CreateOrderUseCase {
       case 'anonymous':
         return { attendantId: null, customerId: null };
       case 'from-request':
-        // Unreachable today: 'from-request' only pairs with requiresAttendant=true.
+        // Invariant: 'from-request' only pairs with requiresAttendant=true (handled above).
+        // Reaching here means a channel policy is misconfigured: a 500-class bug, not user error.
         throw new Error(
           `Channel ${command.orderChannel} mixes 'from-request' with no attendant policy.`,
         );
+      default: {
+        // Compile-time exhaustiveness: a new CustomerSource must be handled above.
+        const _exhaustive: never = source;
+        throw new Error(`Unhandled customer source ${String(_exhaustive)}.`);
+      }
     }
   }
 }

--- a/src/modules/orders/application/use-cases/find-order-by-id.use-case.spec.ts
+++ b/src/modules/orders/application/use-cases/find-order-by-id.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
 import { FindOrderByIdUseCase } from './find-order-by-id.use-case';
 import { OrderNotFoundError } from '../errors/order-not-found.error';
 import type { OrderRepository } from '../../domain/repositories/order.repository';
@@ -15,6 +16,7 @@ const makeOrder = (customerId: string | null): Order =>
     null,
     0,
     0,
+    new Big(0),
     null,
     OrderChannel.APP,
     OrderStatus.PENDING,

--- a/src/modules/orders/application/use-cases/find-order-by-id.use-case.ts
+++ b/src/modules/orders/application/use-cases/find-order-by-id.use-case.ts
@@ -23,10 +23,10 @@ export class FindOrderByIdUseCase {
   async execute(id: string, requester: OrderRequester): Promise<Order> {
     const order = await this.orders.findById(id);
 
-    // A customer can only see their own orders; staff can see any. We return the
-    // same 404 for "missing" and "not yours" so existence is never leaked.
-    // TODO(multi-unit): once the JWT carries the staff member's businessUnitId,
-    // also scope staff visibility to their own unit instead of brand-wide.
+    // Customer sees only their own orders; staff sees any. Same 404 for missing and
+    // not-yours, so existence is never leaked.
+    // TODO(multi-unit): once the JWT carries the staff member's businessUnitId, scope
+    // staff visibility to their own unit instead of brand-wide.
     const hiddenFromCustomer =
       requester.role === UserRole.CUSTOMER && order?.customerId !== requester.id;
 

--- a/src/modules/orders/application/use-cases/list-orders.use-case.spec.ts
+++ b/src/modules/orders/application/use-cases/list-orders.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
 import { ListOrdersUseCase } from './list-orders.use-case';
 import { OrdersFetchError } from '../errors/orders-fetch.error';
 import type { OrderRepository } from '../../domain/repositories/order.repository';
@@ -14,6 +15,7 @@ const makeOrder = (id: string): Order =>
     null,
     0,
     0,
+    new Big(0),
     null,
     OrderChannel.APP,
     OrderStatus.PENDING,

--- a/src/modules/orders/application/use-cases/update-order-status.use-case.spec.ts
+++ b/src/modules/orders/application/use-cases/update-order-status.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
 import { UpdateOrderStatusUseCase } from './update-order-status.use-case';
 import { OrderNotFoundError } from '../errors/order-not-found.error';
 import { OrderStatusConflictError } from '../errors/order-status-conflict.error';
@@ -18,6 +19,7 @@ const makeOrder = (status: OrderStatus): Order =>
     null,
     0,
     0,
+    new Big(0),
     null,
     OrderChannel.APP,
     status,
@@ -59,12 +61,16 @@ describe('UpdateOrderStatusUseCase', () => {
       'staff-1',
     );
 
-    expect(updateStatus).toHaveBeenCalledWith({
-      id: 'o-1',
-      expectedFrom: OrderStatus.PENDING,
-      orderStatus: OrderStatus.CONFIRMED,
-      updatedById: 'staff-1',
-    });
+    expect(updateStatus).toHaveBeenCalledWith(
+      {
+        id: 'o-1',
+        expectedFrom: OrderStatus.PENDING,
+        orderStatus: OrderStatus.CONFIRMED,
+        updatedById: 'staff-1',
+      },
+      undefined,
+    );
+    expect(findById).toHaveBeenCalledWith('o-1', undefined);
     expect(log).toHaveBeenCalledWith(
       expect.objectContaining({
         action: AUDIT_ACTIONS.ORDER_STATUS_CHANGED,
@@ -74,6 +80,32 @@ describe('UpdateOrderStatusUseCase', () => {
         metadata: { from: OrderStatus.PENDING, to: OrderStatus.CONFIRMED },
       }),
     );
+    expect(result.orderStatus).toBe(OrderStatus.CONFIRMED);
+  });
+
+  it('reads/writes inside an injected tx and defers auditing to the caller', async () => {
+    findById.mockResolvedValue(makeOrder(OrderStatus.PENDING));
+    updateStatus.mockResolvedValue(makeOrder(OrderStatus.CONFIRMED));
+    const tx = {} as unknown; // opaque transaction context
+
+    const result = await useCase.execute(
+      { orderId: 'o-1', orderStatus: OrderStatus.CONFIRMED },
+      null,
+      tx,
+    );
+
+    expect(findById).toHaveBeenCalledWith('o-1', tx);
+    expect(updateStatus).toHaveBeenCalledWith(
+      {
+        id: 'o-1',
+        expectedFrom: OrderStatus.PENDING,
+        orderStatus: OrderStatus.CONFIRMED,
+        updatedById: null,
+      },
+      tx,
+    );
+    // With a tx the write is not durable yet, so the use case must not audit here.
+    expect(log).not.toHaveBeenCalled();
     expect(result.orderStatus).toBe(OrderStatus.CONFIRMED);
   });
 

--- a/src/modules/orders/application/use-cases/update-order-status.use-case.ts
+++ b/src/modules/orders/application/use-cases/update-order-status.use-case.ts
@@ -7,6 +7,7 @@ import {
 import type { OrderStatus } from '@modules/orders/domain/value-objects/order-status';
 import { AUDIT_LOGGER, type AuditLogger } from '@modules/audit/application/ports/audit-logger.port';
 import { AUDIT_ACTIONS } from '@modules/audit/domain/audit-actions';
+import type { TransactionContext } from '@shared/transaction/transaction-runner.port';
 import { OrderNotFoundError } from '../errors/order-not-found.error';
 import { OrderStatusConflictError } from '../errors/order-status-conflict.error';
 
@@ -24,8 +25,14 @@ export class UpdateOrderStatusUseCase {
     private readonly audit: AuditLogger,
   ) {}
 
-  async execute(command: UpdateOrderStatusCommand, actorId: string): Promise<Order> {
-    const order = await this.orders.findById(command.orderId);
+  async execute(
+    command: UpdateOrderStatusCommand,
+    actorId: string | null,
+    tx?: TransactionContext,
+  ): Promise<Order> {
+    // Read inside the caller's tx (when present) so this read and the write below share
+    // one snapshot; the optimistic lock still guards the actual transition.
+    const order = await this.orders.findById(command.orderId, tx);
     if (!order) {
       throw new OrderNotFoundError(`Order ${command.orderId} was not found.`);
     }
@@ -35,12 +42,15 @@ export class UpdateOrderStatusUseCase {
 
     // Optimistic lock: the write only applies if the status we read still holds.
     // A null result means another request transitioned the order in between (409).
-    const updated = await this.orders.updateStatus({
-      id: command.orderId,
-      expectedFrom: order.orderStatus,
-      orderStatus: command.orderStatus,
-      updatedById: actorId,
-    });
+    const updated = await this.orders.updateStatus(
+      {
+        id: command.orderId,
+        expectedFrom: order.orderStatus,
+        orderStatus: command.orderStatus,
+        updatedById: actorId,
+      },
+      tx,
+    );
 
     if (!updated) {
       throw new OrderStatusConflictError(
@@ -48,13 +58,19 @@ export class UpdateOrderStatusUseCase {
       );
     }
 
-    await this.audit.log({
-      userId: actorId,
-      action: AUDIT_ACTIONS.ORDER_STATUS_CHANGED,
-      entity: 'Order',
-      entityId: command.orderId,
-      metadata: { from: order.orderStatus, to: command.orderStatus },
-    });
+    // Audit only when this use case owns the write. With an injected tx the change is not
+    // durable until the caller commits, so logging here could record a transition that
+    // later rolls back; the transactional caller owns post-commit auditing (the payment
+    // confirm path is already captured by PAYMENT_APPROVED in ConfirmPaymentUseCase).
+    if (!tx) {
+      await this.audit.log({
+        userId: actorId,
+        action: AUDIT_ACTIONS.ORDER_STATUS_CHANGED,
+        entity: 'Order',
+        entityId: command.orderId,
+        metadata: { from: order.orderStatus, to: command.orderStatus },
+      });
+    }
 
     return updated;
   }

--- a/src/modules/orders/domain/entities/order-item.entity.spec.ts
+++ b/src/modules/orders/domain/entities/order-item.entity.spec.ts
@@ -14,7 +14,7 @@ describe('OrderItem', () => {
   });
 
   describe('constructor enforces the subtotal invariant', () => {
-    it('computes subtotal from quantity and unitPrice — caller cannot pass an inconsistent value', () => {
+    it('computes subtotal from quantity and unitPrice - caller cannot pass an inconsistent value', () => {
       const item = new OrderItem('i-1', 'o-1', 'p-1', 4, new Big('7.25'), null);
 
       expect(item.subtotal.eq(new Big('29'))).toBe(true);

--- a/src/modules/orders/domain/entities/order-item.entity.ts
+++ b/src/modules/orders/domain/entities/order-item.entity.ts
@@ -1,7 +1,7 @@
 import Big from 'big.js';
 
 export class OrderItem {
-  /** Line total (`quantity × unitPrice`), computed once at construction with `big.js` — never a float. */
+  /** Line total (`quantity x unitPrice`), computed once at construction with `big.js` - never a float. */
   public readonly subtotal: Big;
 
   constructor(

--- a/src/modules/orders/domain/entities/order.entity.spec.ts
+++ b/src/modules/orders/domain/entities/order.entity.spec.ts
@@ -5,6 +5,31 @@ import { OrderItem } from './order-item.entity';
 import { OrderChannel } from '../value-objects/order-channel';
 import { OrderStatus } from '../value-objects/order-status';
 import { InvalidOrderStatusTransitionError } from '../errors/invalid-order-status-transition.error';
+import { InvalidOrderTotalError } from '../errors/invalid-order-total.error';
+
+// Two lines summing to a gross subtotal of 25.50.
+const sampleItems = (): OrderItem[] => [
+  new OrderItem('i-1', 'o-1', 'p-1', 2, new Big('10'), null),
+  new OrderItem('i-2', 'o-1', 'p-2', 1, new Big('5.50'), null),
+];
+
+const makeOrder = (totalAmount: Big, orderItems: OrderItem[] = sampleItems()): Order =>
+  new Order(
+    'o-1',
+    'bu-1',
+    'c-1',
+    null,
+    0,
+    0,
+    totalAmount,
+    null,
+    OrderChannel.APP,
+    OrderStatus.PENDING,
+    new Date(),
+    new Date(),
+    null,
+    orderItems,
+  );
 
 const orderWithStatus = (status: OrderStatus): Order =>
   new Order(
@@ -14,6 +39,7 @@ const orderWithStatus = (status: OrderStatus): Order =>
     null,
     0,
     0,
+    new Big(0),
     null,
     OrderChannel.APP,
     status,
@@ -24,40 +50,59 @@ const orderWithStatus = (status: OrderStatus): Order =>
   );
 
 describe('Order', () => {
-  describe('calculateTotalAmount', () => {
+  describe('calculateItemsSubtotal', () => {
     it('sums the item subtotals', () => {
-      expect(Order.calculateTotalAmount(['37.5', '9.99']).eq(new Big('47.49'))).toBe(true);
+      expect(Order.calculateItemsSubtotal(['37.5', '9.99']).eq(new Big('47.49'))).toBe(true);
     });
 
     it('returns 0 for an empty order', () => {
-      expect(Order.calculateTotalAmount([]).eq(new Big(0))).toBe(true);
+      expect(Order.calculateItemsSubtotal([]).eq(new Big(0))).toBe(true);
     });
   });
 
-  describe('constructor enforces the totalAmount invariant', () => {
-    it('computes totalAmount from the items it was constructed with', () => {
-      const items = [
-        new OrderItem('i-1', 'o-1', 'p-1', 2, new Big('10'), null),
-        new OrderItem('i-2', 'o-1', 'p-2', 1, new Big('5.50'), null),
-      ];
+  describe('computeTotal (discount rule)', () => {
+    it('subtracts the discount from the gross subtotal', () => {
+      expect(Order.computeTotal(new Big('25.50'), new Big('5.50')).eq(new Big('20'))).toBe(true);
+    });
 
-      const order = new Order(
-        'o-1',
-        'bu-1',
-        'c-1',
-        null,
-        0,
-        0,
-        null,
-        OrderChannel.APP,
-        'PENDING',
-        new Date(),
-        new Date(),
-        null,
-        items,
+    it('equals the subtotal when there is no discount', () => {
+      expect(Order.computeTotal(new Big('25.50'), new Big(0)).eq(new Big('25.50'))).toBe(true);
+    });
+
+    it('rejects a negative discount (a surcharge)', () => {
+      expect(() => Order.computeTotal(new Big('25.50'), new Big('-1'))).toThrow(
+        InvalidOrderTotalError,
       );
+    });
 
-      expect(order.totalAmount.eq(new Big('25.50'))).toBe(true);
+    it('rejects a discount larger than the subtotal', () => {
+      expect(() => Order.computeTotal(new Big('25.50'), new Big('30'))).toThrow(
+        InvalidOrderTotalError,
+      );
+    });
+  });
+
+  describe('constructor total/discount', () => {
+    it('exposes the gross subtotal computed from its items', () => {
+      expect(makeOrder(new Big('25.50')).itemsSubtotal.eq(new Big('25.50'))).toBe(true);
+    });
+
+    it('keeps the persisted total authoritative and derives the discount', () => {
+      const order = makeOrder(new Big('20'));
+      expect(order.totalAmount.eq(new Big('20'))).toBe(true);
+      expect(order.discountAmount.eq(new Big('5.50'))).toBe(true);
+    });
+
+    it('derives a zero discount when total equals the subtotal', () => {
+      expect(makeOrder(new Big('25.50')).discountAmount.eq(new Big(0))).toBe(true);
+    });
+
+    it('rejects a total above the subtotal (corrupt data)', () => {
+      expect(() => makeOrder(new Big('30'))).toThrow(InvalidOrderTotalError);
+    });
+
+    it('rejects a negative total', () => {
+      expect(() => makeOrder(new Big('-1'))).toThrow(InvalidOrderTotalError);
     });
   });
 

--- a/src/modules/orders/domain/entities/order.entity.ts
+++ b/src/modules/orders/domain/entities/order.entity.ts
@@ -3,9 +3,13 @@ import { canTransition, type OrderStatus } from '../value-objects/order-status';
 import type { OrderChannel } from '../value-objects/order-channel';
 import { OrderItem } from './order-item.entity';
 import { InvalidOrderStatusTransitionError } from '../errors/invalid-order-status-transition.error';
+import { InvalidOrderTotalError } from '../errors/invalid-order-total.error';
 
 export class Order {
-  public readonly totalAmount: Big;
+  /** Gross sum of the line subtotals, before any discount. */
+  public readonly itemsSubtotal: Big;
+  /** Amount knocked off the gross subtotal (itemsSubtotal - totalAmount); 0 when nothing was discounted. */
+  public readonly discountAmount: Big;
 
   constructor(
     public readonly id: string,
@@ -14,6 +18,8 @@ export class Order {
     public readonly attendantId: string | null,
     public readonly pointsRedeemed: number,
     public readonly pointsEarned: number,
+    /** Authoritative amount charged, net of discount. Supplied by persistence, never recomputed here. */
+    public readonly totalAmount: Big,
     public readonly notes: string | null,
     public readonly orderChannel: OrderChannel,
     public readonly orderStatus: OrderStatus,
@@ -22,11 +28,36 @@ export class Order {
     public readonly updatedById: string | null,
     public readonly orderItems: OrderItem[],
   ) {
-    this.totalAmount = Order.calculateTotalAmount(orderItems.map((i) => i.subtotal));
+    this.itemsSubtotal = Order.calculateItemsSubtotal(orderItems.map((i) => i.subtotal));
+    this.discountAmount = this.itemsSubtotal.minus(totalAmount);
+    // Reject a persisted total that breaks the discount band (corrupt data guard).
+    Order.assertDiscountWithinBand(this.discountAmount, this.itemsSubtotal);
   }
 
-  static calculateTotalAmount(subtotals: ReadonlyArray<Big | string>): Big {
+  /** Sums the line subtotals into the gross amount, before any discount. */
+  static calculateItemsSubtotal(subtotals: ReadonlyArray<Big | string>): Big {
     return subtotals.reduce<Big>((acc, curr) => acc.plus(new Big(curr)), new Big(0));
+  }
+
+  /**
+   * The discount rule: the charged total is the gross subtotal minus the discount.
+   * The discount must sit in [0, subtotal] - never negative (a surcharge) nor larger
+   * than the subtotal. Throws {@link InvalidOrderTotalError} otherwise. Callers pass 0
+   * today; the loyalty module will supply the points-based discount.
+   */
+  static computeTotal(itemsSubtotal: Big, discountAmount: Big): Big {
+    Order.assertDiscountWithinBand(discountAmount, itemsSubtotal);
+    return itemsSubtotal.minus(discountAmount);
+  }
+
+  private static assertDiscountWithinBand(discountAmount: Big, itemsSubtotal: Big): void {
+    if (discountAmount.lt(0) || discountAmount.gt(itemsSubtotal)) {
+      throw new InvalidOrderTotalError(
+        `Discount ${discountAmount.toFixed(2)} is outside the allowed range [0, ${itemsSubtotal.toFixed(
+          2,
+        )}].`,
+      );
+    }
   }
 
   /**

--- a/src/modules/orders/domain/errors/invalid-order-total.error.ts
+++ b/src/modules/orders/domain/errors/invalid-order-total.error.ts
@@ -1,0 +1,13 @@
+import { DomainError } from '@shared/errors/domain/domain.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/**
+ * The order total breaks the discount invariant: it must be a non-negative amount no
+ * greater than the gross items subtotal (discount in the range [0, subtotal]). Guards
+ * both the write-time computation and reconstitution from a corrupt persisted total.
+ */
+export class InvalidOrderTotalError extends DomainError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.INVALID, message, options);
+  }
+}

--- a/src/modules/orders/domain/repositories/order.repository.ts
+++ b/src/modules/orders/domain/repositories/order.repository.ts
@@ -39,15 +39,17 @@ export interface UpdateOrderStatusInput {
   /** The status the caller read; the update only applies if the row still holds it. */
   expectedFrom: OrderStatus;
   orderStatus: OrderStatus;
-  updatedById: string;
+  /** `null` when the transition is performed by the system (e.g. a payment hook). */
+  updatedById: string | null;
 }
 
 export interface OrderRepository {
   create(input: CreateOrderInput, tx?: TransactionContext): Promise<Order>;
-  findById(id: string): Promise<Order | null>;
+  /** Pass `tx` to read inside an open transaction (read + later write share one snapshot). */
+  findById(id: string, tx?: TransactionContext): Promise<Order | null>;
   findMany(input: FindOrdersInput): Promise<Order[]>;
   /** Returns `null` when no row matched the expected "from" status (concurrent change). */
-  updateStatus(input: UpdateOrderStatusInput): Promise<Order | null>;
+  updateStatus(input: UpdateOrderStatusInput, tx?: TransactionContext): Promise<Order | null>;
 }
 
 export const ORDER_REPOSITORY = Symbol('OrderRepository');

--- a/src/modules/orders/domain/value-objects/order-channel.ts
+++ b/src/modules/orders/domain/value-objects/order-channel.ts
@@ -11,7 +11,7 @@ export type OrderChannel = (typeof OrderChannel)[keyof typeof OrderChannel];
 /**
  * Where the order's customer comes from:
  * - `authenticated`: the logged-in user placing the order (APP, WEB).
- * - `anonymous`: no customer is attached — a walk-up self-service order (TOTEM).
+ * - `anonymous`: no customer is attached - a walk-up self-service order (TOTEM).
  * - `from-request`: a staff member supplies the customer in the request body (COUNTER, PICKUP).
  */
 type CustomerSource = 'authenticated' | 'anonymous' | 'from-request';
@@ -23,7 +23,7 @@ interface ChannelPolicy {
 
 /**
  * Per-channel rules: whether a staff attendant must place the order, and how its
- * customer is resolved. This table is the single source of truth — callers ask via
+ * customer is resolved. This table is the single source of truth - callers ask via
  * the helpers below instead of branching on the channel.
  */
 const POLICIES: Record<OrderChannel, ChannelPolicy> = {

--- a/src/modules/orders/infrastructure/http/controllers/orders.controller.spec.ts
+++ b/src/modules/orders/infrastructure/http/controllers/orders.controller.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
 import { Test } from '@nestjs/testing';
 import { OrdersController } from './orders.controller';
 import { CreateOrderUseCase } from '@modules/orders/application/use-cases/create-order.use-case';
@@ -21,6 +22,7 @@ const buildOrder = (id = 'o-1', status: OrderStatus = OrderStatus.PENDING): Orde
     null,
     0,
     0,
+    new Big(0),
     null,
     OrderChannel.APP,
     status,

--- a/src/modules/orders/infrastructure/http/dto/order-response.dto.spec.ts
+++ b/src/modules/orders/infrastructure/http/dto/order-response.dto.spec.ts
@@ -14,6 +14,7 @@ describe('OrderResponseDto.fromEntity', () => {
     null,
     0,
     5,
+    new Big('20'),
     'note',
     OrderChannel.APP,
     'PENDING',

--- a/src/modules/orders/infrastructure/http/dto/paginated-order-response.dto.ts
+++ b/src/modules/orders/infrastructure/http/dto/paginated-order-response.dto.ts
@@ -5,7 +5,7 @@ import { OrderResponseDto } from './order-response.dto';
 /**
  * Schema-only DTO: never instantiated at runtime. It exists so Swagger can
  * describe the generic `PaginatedResponseDto<OrderResponseDto>` returned by
- * the list endpoint (OpenAPI has no generics — a concrete class is needed).
+ * the list endpoint (OpenAPI has no generics - a concrete class is needed).
  */
 export class PaginatedOrderResponseDto {
   @ApiProperty({ type: [OrderResponseDto] })

--- a/src/modules/orders/infrastructure/persistence/prisma-order.repository.ts
+++ b/src/modules/orders/infrastructure/persistence/prisma-order.repository.ts
@@ -49,8 +49,10 @@ export class PrismaOrderRepository implements OrderRepository {
     }
   }
 
-  async findById(id: string): Promise<Order | null> {
-    const raw = await this.prisma.order.findUnique({
+  async findById(id: string, tx?: TransactionContext): Promise<Order | null> {
+    const db = (tx as Prisma.TransactionClient) ?? this.prisma;
+
+    const raw = await db.order.findUnique({
       where: { id },
       include: { orderItems: true },
     });
@@ -74,12 +76,17 @@ export class PrismaOrderRepository implements OrderRepository {
     return raws.map((raw) => this.toEntity(raw));
   }
 
-  async updateStatus(input: UpdateOrderStatusInput): Promise<Order | null> {
-    // Optimistic lock: the write only lands if the row still holds the status the
-    // caller read. updateMany lets us filter on a non-unique column and tells us how
-    // many rows matched — 0 means someone transitioned the order concurrently.
+  async updateStatus(
+    input: UpdateOrderStatusInput,
+    tx?: TransactionContext,
+  ): Promise<Order | null> {
+    const db = (tx as Prisma.TransactionClient) ?? this.prisma;
+
+    // Optimistic lock: the write only lands if the row still holds the status the caller
+    // read. updateMany filters on a non-unique column and returns the match count; 0
+    // means someone transitioned the order concurrently.
     try {
-      const { count } = await this.prisma.order.updateMany({
+      const { count } = await db.order.updateMany({
         where: { id: input.id, orderStatus: input.expectedFrom },
         data: { orderStatus: input.orderStatus, updatedById: input.updatedById },
       });
@@ -88,7 +95,7 @@ export class PrismaOrderRepository implements OrderRepository {
         return null;
       }
 
-      const updated = await this.prisma.order.findUnique({
+      const updated = await db.order.findUnique({
         where: { id: input.id },
         include: { orderItems: true },
       });
@@ -159,6 +166,7 @@ export class PrismaOrderRepository implements OrderRepository {
       raw.attendantId,
       raw.pointsRedeemed,
       raw.pointsEarned,
+      new Big(raw.totalAmount.toString()),
       raw.notes,
       raw.orderChannel,
       raw.orderStatus,

--- a/src/modules/orders/orders.module.ts
+++ b/src/modules/orders/orders.module.ts
@@ -11,6 +11,8 @@ import { PrismaOrderProductLookup } from './infrastructure/persistence/prisma-or
 import { TRANSACTION_RUNNER } from '@shared/transaction/transaction-runner.port';
 import { PrismaTransactionRunner } from '@shared/infrastructure/prisma/prisma-transaction-runner';
 import { AuditModule } from '@modules/audit/audit.module';
+import { ORDER_FOR_PAYMENT } from './application/ports/order-for-payment.port';
+import { OrderForPaymentService } from './application/services/order-for-payment.service';
 
 @Module({
   imports: [AuditModule],
@@ -28,10 +30,15 @@ import { AuditModule } from '@modules/audit/audit.module';
       provide: TRANSACTION_RUNNER,
       useClass: PrismaTransactionRunner,
     },
+    {
+      provide: ORDER_FOR_PAYMENT,
+      useClass: OrderForPaymentService,
+    },
     CreateOrderUseCase,
     FindOrderByIdUseCase,
     ListOrdersUseCase,
     UpdateOrderStatusUseCase,
   ],
+  exports: [ORDER_FOR_PAYMENT],
 })
 export class OrdersModule {}

--- a/src/modules/payments/application/errors/order-not-found.error.ts
+++ b/src/modules/payments/application/errors/order-not-found.error.ts
@@ -1,0 +1,9 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/** The order a payment targets does not exist. */
+export class OrderNotFoundError extends ApplicationError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.NOT_FOUND, message, options);
+  }
+}

--- a/src/modules/payments/application/errors/order-not-payable.error.ts
+++ b/src/modules/payments/application/errors/order-not-payable.error.ts
@@ -1,0 +1,9 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/** The order cannot be paid: it is not PENDING, or it already has a payment. */
+export class OrderNotPayableError extends ApplicationError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.INVALID, message, options);
+  }
+}

--- a/src/modules/payments/application/errors/payment-charge-failed.error.ts
+++ b/src/modules/payments/application/errors/payment-charge-failed.error.ts
@@ -1,0 +1,18 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/**
+ * The gateway charge could not be completed (technical failure). Maps to 503: a transient
+ * gateway problem, not the caller's fault. `ambiguous` records whether the outcome is
+ * unknown (money may have moved) - when true the attempt is kept for reconciliation and a
+ * blind retry is blocked by the live-attempt guard, so the caller cannot double-charge.
+ */
+export class PaymentChargeFailedError extends ApplicationError {
+  constructor(
+    message: string,
+    readonly ambiguous: boolean,
+    options?: { cause?: unknown },
+  ) {
+    super(ERROR_KINDS.UNAVAILABLE, message, options);
+  }
+}

--- a/src/modules/payments/application/errors/payment-not-found.error.ts
+++ b/src/modules/payments/application/errors/payment-not-found.error.ts
@@ -1,0 +1,9 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/** A requested payment could not be found (or is not visible to the requester). */
+export class PaymentNotFoundError extends ApplicationError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.NOT_FOUND, message, options);
+  }
+}

--- a/src/modules/payments/application/ports/payment-gateway.port.ts
+++ b/src/modules/payments/application/ports/payment-gateway.port.ts
@@ -1,0 +1,47 @@
+import type Big from 'big.js';
+import type { PaymentStatus } from '../../domain/value-objects/payment-status';
+
+export const PAYMENT_GATEWAY = Symbol('PaymentGateway');
+
+export interface ChargeRequest {
+  orderId: string;
+  /**
+   * Per-attempt idempotency key (the payment attempt id). The gateway de-dupes on it:
+   * the same key charged twice yields one charge and the original result. This is what
+   * makes a retried charge call safe (network timeout, client retry).
+   */
+  idempotencyKey: string;
+}
+
+export interface ChargeResult {
+  /** The gateway's own transaction id, echoed back later by its webhook. */
+  extTransactionId: string;
+  /**
+   * The gateway's synchronous decision. The webhook is what ultimately applies the
+   * outcome to us, so the create flow does NOT consume this field - it persists the
+   * attempt as PROCESSING and waits for the webhook (mirrors Stripe/Mercado Pago).
+   */
+  status: typeof PaymentStatus.APPROVED | typeof PaymentStatus.REFUSED;
+  raw: Record<string, unknown>;
+}
+
+export interface PaymentGateway {
+  charge(amount: Big, request: ChargeRequest): Promise<ChargeResult>;
+}
+
+/**
+ * Raised by a gateway adapter when a charge call fails (technical failure, not a business
+ * decline - declines come back as a REFUSED outcome via the webhook). `ambiguous` is the
+ * decisive flag: when true the charge may or may not have moved money (e.g. a timeout), so
+ * the attempt must be kept (slot held) for reconciliation rather than freed for retry.
+ */
+export class PaymentGatewayError extends Error {
+  constructor(
+    message: string,
+    readonly ambiguous: boolean,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = new.target.name;
+  }
+}

--- a/src/modules/payments/application/use-cases/confirm-payment.use-case.spec.ts
+++ b/src/modules/payments/application/use-cases/confirm-payment.use-case.spec.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
+import { ConfirmPaymentUseCase } from './confirm-payment.use-case';
+import type { PaymentRepository } from '../../domain/repositories/payment.repository';
+import type { OrderForPayment } from '@modules/orders/application/ports/order-for-payment.port';
+import type { AuditLogger } from '@modules/audit/application/ports/audit-logger.port';
+import type { TransactionRunner } from '@shared/transaction/transaction-runner.port';
+import { AUDIT_ACTIONS } from '@modules/audit/domain/audit-actions';
+import { Payment } from '../../domain/entities/payment.entity';
+import { PaymentMethod } from '../../domain/value-objects/payment-method';
+import { PaymentStatus } from '../../domain/value-objects/payment-status';
+
+const TX = Symbol('tx');
+
+const makePayment = (status: PaymentStatus): Payment =>
+  new Payment(
+    'pay-1',
+    'order-1',
+    new Big('25.00'),
+    PaymentMethod.PIX,
+    status,
+    'tx-1',
+    new Date(),
+    new Date(),
+  );
+
+describe('ConfirmPaymentUseCase', () => {
+  let payments: jest.Mocked<PaymentRepository>;
+  let orders: jest.Mocked<OrderForPayment>;
+  let transactions: TransactionRunner;
+  let audit: { log: jest.Mock };
+  let useCase: ConfirmPaymentUseCase;
+
+  beforeEach(() => {
+    payments = {
+      create: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findCurrentByOrderId: jest.fn(),
+      findByExtTransactionId: jest.fn(),
+      markCharged: jest.fn(),
+      updateStatus: jest.fn(),
+      settle: jest.fn(),
+    } as unknown as jest.Mocked<PaymentRepository>;
+    orders = {
+      findForPayment: jest.fn(),
+      confirmAfterPayment: jest.fn(),
+    } as unknown as jest.Mocked<OrderForPayment>;
+    transactions = {
+      run: jest.fn(async (work: (tx: unknown) => Promise<unknown>) => work(TX)),
+    } as unknown as TransactionRunner;
+    audit = { log: jest.fn() };
+
+    useCase = new ConfirmPaymentUseCase(
+      payments,
+      orders,
+      transactions,
+      audit as unknown as AuditLogger,
+    );
+  });
+
+  it('approves a payment, confirms the order in the same tx, and audits PAYMENT_APPROVED', async () => {
+    payments.findByExtTransactionId.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+    payments.settle.mockResolvedValue(makePayment(PaymentStatus.APPROVED));
+    orders.confirmAfterPayment.mockResolvedValue('confirmed');
+
+    const result = await useCase.execute({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      amount: '25.00',
+    });
+
+    expect(payments.settle).toHaveBeenCalledWith(
+      { id: 'pay-1', status: PaymentStatus.APPROVED },
+      TX,
+    );
+    expect(orders.confirmAfterPayment).toHaveBeenCalledWith('order-1', TX);
+    expect(audit.log).toHaveBeenCalledTimes(1);
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_APPROVED, entity: 'Payment' }),
+    );
+    expect(result?.status).toBe(PaymentStatus.APPROVED);
+  });
+
+  it('settles the payment but flags reconciliation when the order is no longer confirmable', async () => {
+    payments.findByExtTransactionId.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+    payments.settle.mockResolvedValue(makePayment(PaymentStatus.APPROVED));
+    orders.confirmAfterPayment.mockResolvedValue('not_confirmed');
+
+    const result = await useCase.execute({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      amount: '25.00',
+    });
+
+    // Payment still settled (no rollback), plus a reconciliation audit entry.
+    expect(payments.settle).toHaveBeenCalledWith(
+      { id: 'pay-1', status: PaymentStatus.APPROVED },
+      TX,
+    );
+    expect(result?.status).toBe(PaymentStatus.APPROVED);
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_APPROVED }),
+    );
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED }),
+    );
+  });
+
+  it('refuses a payment without confirming the order, auditing PAYMENT_REFUSED', async () => {
+    payments.findByExtTransactionId.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+    payments.settle.mockResolvedValue(makePayment(PaymentStatus.REFUSED));
+
+    await useCase.execute({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.REFUSED,
+      amount: '25.00',
+    });
+
+    expect(orders.confirmAfterPayment).not.toHaveBeenCalled();
+    expect(audit.log).toHaveBeenCalledTimes(1);
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_REFUSED }),
+    );
+  });
+
+  it('acks an unknown transaction as a no-op and records reconciliation (no 404)', async () => {
+    payments.findByExtTransactionId.mockResolvedValue(null);
+
+    const result = await useCase.execute({
+      extTransactionId: 'missing',
+      status: PaymentStatus.APPROVED,
+      amount: '25.00',
+    });
+
+    expect(result).toBeNull();
+    expect(payments.settle).not.toHaveBeenCalled();
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED }),
+    );
+  });
+
+  it('never settles when the webhook amount differs from the charged amount; flags reconciliation', async () => {
+    payments.findByExtTransactionId.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+
+    const result = await useCase.execute({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      amount: '30.00',
+    });
+
+    expect(result).toBeNull();
+    expect(payments.settle).not.toHaveBeenCalled();
+    expect(orders.confirmAfterPayment).not.toHaveBeenCalled();
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED }),
+    );
+  });
+
+  it('is idempotent: a payment already settled is returned unchanged (webhook redelivery)', async () => {
+    payments.findByExtTransactionId.mockResolvedValue(makePayment(PaymentStatus.APPROVED));
+
+    const result = await useCase.execute({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      amount: '25.00',
+    });
+
+    expect(result?.status).toBe(PaymentStatus.APPROVED);
+    expect(payments.settle).not.toHaveBeenCalled();
+    expect(orders.confirmAfterPayment).not.toHaveBeenCalled();
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+
+  it('treats a concurrent redelivery (settle matched no row) as a no-op, returning the settled payment', async () => {
+    // Still PROCESSING at the top check, but another delivery settles it first -> settle null.
+    payments.findByExtTransactionId
+      .mockResolvedValueOnce(makePayment(PaymentStatus.PROCESSING))
+      .mockResolvedValueOnce(makePayment(PaymentStatus.APPROVED));
+    payments.settle.mockResolvedValue(null);
+
+    const result = await useCase.execute({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      amount: '25.00',
+    });
+
+    expect(result?.status).toBe(PaymentStatus.APPROVED);
+    expect(orders.confirmAfterPayment).not.toHaveBeenCalled();
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/payments/application/use-cases/confirm-payment.use-case.ts
+++ b/src/modules/payments/application/use-cases/confirm-payment.use-case.ts
@@ -1,0 +1,139 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import Big from 'big.js';
+import {
+  ORDER_FOR_PAYMENT,
+  type OrderForPayment,
+} from '@modules/orders/application/ports/order-for-payment.port';
+import {
+  AUDIT_LOGGER,
+  type AuditLogger,
+  type AuditLogInput,
+} from '@modules/audit/application/ports/audit-logger.port';
+import { AUDIT_ACTIONS } from '@modules/audit/domain/audit-actions';
+import {
+  TRANSACTION_RUNNER,
+  type TransactionRunner,
+} from '@shared/transaction/transaction-runner.port';
+import { Payment } from '../../domain/entities/payment.entity';
+import { PaymentStatus } from '../../domain/value-objects/payment-status';
+import {
+  PAYMENT_REPOSITORY,
+  type PaymentRepository,
+} from '../../domain/repositories/payment.repository';
+export interface ConfirmPaymentCommand {
+  extTransactionId: string;
+  status: typeof PaymentStatus.APPROVED | typeof PaymentStatus.REFUSED;
+  /** Amount the gateway settled, echoed in the webhook; must match what we charged. */
+  amount: string;
+}
+
+@Injectable()
+export class ConfirmPaymentUseCase {
+  private readonly logger = new Logger(ConfirmPaymentUseCase.name);
+
+  constructor(
+    @Inject(PAYMENT_REPOSITORY)
+    private readonly payments: PaymentRepository,
+    @Inject(ORDER_FOR_PAYMENT)
+    private readonly orders: OrderForPayment,
+    @Inject(TRANSACTION_RUNNER)
+    private readonly transactions: TransactionRunner,
+    @Inject(AUDIT_LOGGER)
+    private readonly audit: AuditLogger,
+  ) {}
+
+  async execute(command: ConfirmPaymentCommand): Promise<Payment | null> {
+    const payment = await this.payments.findByExtTransactionId(command.extTransactionId);
+    if (!payment) {
+      // Unknown transaction: record for reconciliation and ack. Returning a non-2xx here
+      // would make the gateway redeliver forever (e.g. for an orphan attempt whose
+      // PROCESSING write was lost, which can never match, or an event from another env).
+      await this.logBestEffort({
+        userId: null,
+        action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED,
+        entity: 'Payment',
+        entityId: command.extTransactionId,
+        metadata: { reason: 'webhook for an unknown transaction', status: command.status },
+      });
+      return null;
+    }
+
+    // Webhooks can be redelivered: a payment already settled is returned unchanged.
+    if (payment.status === PaymentStatus.APPROVED || payment.status === PaymentStatus.REFUSED) {
+      return payment;
+    }
+
+    // Integrity: never settle on an amount that differs from what we charged. Flag it for
+    // reconciliation (tampering, or a gateway/our-side bug) and ack without settling.
+    if (!payment.amount.eq(new Big(command.amount))) {
+      await this.logBestEffort({
+        userId: null,
+        action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED,
+        entity: 'Payment',
+        entityId: payment.id,
+        metadata: {
+          orderId: payment.orderId,
+          reason: 'webhook amount does not match the charged amount',
+          expected: payment.amount.toFixed(2),
+          received: command.amount,
+        },
+      });
+      return null;
+    }
+
+    const approved = command.status === PaymentStatus.APPROVED;
+
+    // Settle the payment and advance the order in one transaction. The order confirm is
+    // best-effort: if it loses the optimistic lock the payment still settles, and we log
+    // it for reconciliation below.
+    const outcome = await this.transactions.run(async (tx) => {
+      // If another webhook delivery already settled this payment, settle returns null,
+      // so we skip the order confirm and audit.
+      const next = await this.payments.settle({ id: payment.id, status: command.status }, tx);
+      if (!next) {
+        return { settled: false as const };
+      }
+      const confirmed = approved
+        ? (await this.orders.confirmAfterPayment(payment.orderId, tx)) === 'confirmed'
+        : false;
+      return { settled: true as const, payment: next, orderConfirmed: confirmed };
+    });
+
+    if (!outcome.settled) {
+      const current = await this.payments.findByExtTransactionId(command.extTransactionId);
+      return current ?? payment;
+    }
+
+    const { payment: updated, orderConfirmed } = outcome;
+
+    await this.logBestEffort({
+      userId: null,
+      action: approved ? AUDIT_ACTIONS.PAYMENT_APPROVED : AUDIT_ACTIONS.PAYMENT_REFUSED,
+      entity: 'Payment',
+      entityId: payment.id,
+      metadata: { orderId: payment.orderId, status: command.status },
+    });
+
+    if (approved && !orderConfirmed) {
+      await this.logBestEffort({
+        userId: null,
+        action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED,
+        entity: 'Payment',
+        entityId: payment.id,
+        metadata: { orderId: payment.orderId, reason: 'order was not PENDING at approval' },
+      });
+    }
+
+    return updated;
+  }
+
+  // A failed audit write must not 500 the webhook, or the gateway redelivers forever.
+  // The payment is already settled, so log and move on (an Outbox would be the real fix).
+  private async logBestEffort(input: AuditLogInput): Promise<void> {
+    try {
+      await this.audit.log(input);
+    } catch (err) {
+      this.logger.error(`Failed to write audit ${input.action} for ${input.entityId}`, err);
+    }
+  }
+}

--- a/src/modules/payments/application/use-cases/create-payment.use-case.spec.ts
+++ b/src/modules/payments/application/use-cases/create-payment.use-case.spec.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
+import { CreatePaymentUseCase } from './create-payment.use-case';
+import type { PaymentRepository } from '../../domain/repositories/payment.repository';
+import type { PaymentGateway } from '../ports/payment-gateway.port';
+import type { OrderForPayment } from '@modules/orders/application/ports/order-for-payment.port';
+import type { AuditLogger } from '@modules/audit/application/ports/audit-logger.port';
+import { AUDIT_ACTIONS } from '@modules/audit/domain/audit-actions';
+import { Payment } from '../../domain/entities/payment.entity';
+import { PaymentMethod } from '../../domain/value-objects/payment-method';
+import { PaymentStatus } from '../../domain/value-objects/payment-status';
+import { UserRole } from '@modules/identity/domain/value-objects/user-role';
+import { OrderNotFoundError } from '../errors/order-not-found.error';
+import { OrderNotPayableError } from '../errors/order-not-payable.error';
+import { PaymentChargeFailedError } from '../errors/payment-charge-failed.error';
+import { PaymentGatewayError } from '../ports/payment-gateway.port';
+
+const makePayment = (status: PaymentStatus): Payment =>
+  new Payment(
+    'pay-1',
+    'order-1',
+    new Big('25.00'),
+    PaymentMethod.PIX,
+    status,
+    status === PaymentStatus.PENDING ? null : 'tx-1',
+    new Date(),
+    new Date(),
+  );
+
+const payableOrder = {
+  id: 'order-1',
+  isAwaitingPayment: true,
+  totalAmount: '25.00',
+  customerId: 'cust-1',
+};
+
+/** The order's own customer - passes the ownership check. */
+const owner = { id: 'cust-1', role: UserRole.CUSTOMER };
+
+describe('CreatePaymentUseCase', () => {
+  let payments: jest.Mocked<PaymentRepository>;
+  let gateway: jest.Mocked<PaymentGateway>;
+  let orders: jest.Mocked<OrderForPayment>;
+  let audit: { log: jest.Mock };
+  let useCase: CreatePaymentUseCase;
+
+  beforeEach(() => {
+    payments = {
+      create: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findCurrentByOrderId: jest.fn(),
+      findByExtTransactionId: jest.fn(),
+      markCharged: jest.fn(),
+      updateStatus: jest.fn(),
+    } as unknown as jest.Mocked<PaymentRepository>;
+    gateway = { charge: jest.fn() } as unknown as jest.Mocked<PaymentGateway>;
+    orders = {
+      findForPayment: jest.fn(),
+      confirmAfterPayment: jest.fn(),
+    } as unknown as jest.Mocked<OrderForPayment>;
+    audit = { log: jest.fn() };
+
+    useCase = new CreatePaymentUseCase(payments, gateway, orders, audit as unknown as AuditLogger);
+  });
+
+  it('reserves a PENDING attempt, charges with its id as idempotency key, then marks it PROCESSING', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder);
+    payments.findActiveByOrderId.mockResolvedValue(null);
+    payments.create.mockResolvedValue(makePayment(PaymentStatus.PENDING));
+    gateway.charge.mockResolvedValue({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      raw: { ok: true },
+    });
+    payments.markCharged.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+
+    const result = await useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner);
+
+    // Reserve happens before the charge, as a PENDING attempt with no ext id yet.
+    expect(payments.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderId: 'order-1',
+        amount: '25.00',
+        status: PaymentStatus.PENDING,
+        extTransactionId: null,
+      }),
+    );
+    // Amount is the order's total; the attempt id is the idempotency key.
+    expect(gateway.charge).toHaveBeenCalledWith(expect.any(Big), {
+      orderId: 'order-1',
+      idempotencyKey: 'pay-1',
+    });
+    expect(gateway.charge.mock.calls[0][0].toFixed(2)).toBe('25.00');
+    expect(payments.markCharged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'pay-1',
+        status: PaymentStatus.PROCESSING,
+        extTransactionId: 'tx-1',
+      }),
+    );
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_CREATED, entity: 'Payment' }),
+    );
+    expect(result.status).toBe(PaymentStatus.PROCESSING);
+  });
+
+  it('throws OrderNotFoundError when the order does not exist (404)', async () => {
+    orders.findForPayment.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner),
+    ).rejects.toBeInstanceOf(OrderNotFoundError);
+
+    expect(payments.create).not.toHaveBeenCalled();
+    expect(gateway.charge).not.toHaveBeenCalled();
+  });
+
+  it('hides another customer order behind the same 404, without reserving or charging', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder); // owned by 'cust-1'
+
+    await expect(
+      useCase.execute(
+        { orderId: 'order-1', method: PaymentMethod.PIX },
+        { id: 'intruder', role: UserRole.CUSTOMER },
+      ),
+    ).rejects.toBeInstanceOf(OrderNotFoundError);
+
+    expect(payments.create).not.toHaveBeenCalled();
+    expect(gateway.charge).not.toHaveBeenCalled();
+  });
+
+  it('lets staff pay an order they do not own', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder); // owned by 'cust-1'
+    payments.findActiveByOrderId.mockResolvedValue(null);
+    payments.create.mockResolvedValue(makePayment(PaymentStatus.PENDING));
+    gateway.charge.mockResolvedValue({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      raw: {},
+    });
+    payments.markCharged.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+
+    await useCase.execute(
+      { orderId: 'order-1', method: PaymentMethod.PIX },
+      { id: 'attendant-9', role: UserRole.ATTENDANT },
+    );
+
+    expect(payments.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws OrderNotPayableError when the order is not awaiting payment (422)', async () => {
+    orders.findForPayment.mockResolvedValue({ ...payableOrder, isAwaitingPayment: false });
+
+    await expect(
+      useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner),
+    ).rejects.toBeInstanceOf(OrderNotPayableError);
+
+    expect(gateway.charge).not.toHaveBeenCalled();
+  });
+
+  it('throws OrderNotPayableError when a live attempt already exists, without charging (422)', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder);
+    payments.findActiveByOrderId.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+
+    await expect(
+      useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner),
+    ).rejects.toBeInstanceOf(OrderNotPayableError);
+
+    expect(payments.create).not.toHaveBeenCalled();
+    expect(gateway.charge).not.toHaveBeenCalled();
+  });
+
+  it('creates a fresh attempt when the only prior payment was refused (no live attempt)', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder);
+    payments.findActiveByOrderId.mockResolvedValue(null); // a REFUSED row is not "active"
+    payments.create.mockResolvedValue(makePayment(PaymentStatus.PENDING));
+    gateway.charge.mockResolvedValue({
+      extTransactionId: 'tx-2',
+      status: PaymentStatus.APPROVED,
+      raw: {},
+    });
+    payments.markCharged.mockResolvedValue(makePayment(PaymentStatus.PROCESSING));
+
+    await useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner);
+
+    expect(payments.create).toHaveBeenCalledTimes(1);
+    expect(gateway.charge).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a reconciliation entry and rethrows when persisting PROCESSING fails after a charge', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder);
+    payments.findActiveByOrderId.mockResolvedValue(null);
+    payments.create.mockResolvedValue(makePayment(PaymentStatus.PENDING));
+    gateway.charge.mockResolvedValue({
+      extTransactionId: 'tx-9',
+      status: PaymentStatus.APPROVED,
+      raw: {},
+    });
+    payments.markCharged.mockRejectedValue(new Error('db write failed'));
+
+    await expect(
+      useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner),
+    ).rejects.toThrow('db write failed');
+
+    // Hold the orphan's slot at PROCESSING so the sweeper can't free it and let a retry
+    // double-charge (the sweeper only cancels PENDING reservations).
+    expect(payments.updateStatus).toHaveBeenCalledWith({
+      id: 'pay-1',
+      status: PaymentStatus.PROCESSING,
+    });
+
+    // Charge succeeded but the write failed: flag the orphan for reconciliation
+    // and never emit PAYMENT_CREATED.
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED,
+        metadata: expect.objectContaining({ extTransactionId: 'tx-9' }),
+      }),
+    );
+    expect(audit.log).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_CREATED }),
+    );
+  });
+
+  it('cancels the attempt and frees the slot on a definite gateway failure', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder);
+    payments.findActiveByOrderId.mockResolvedValue(null);
+    payments.create.mockResolvedValue(makePayment(PaymentStatus.PENDING));
+    gateway.charge.mockRejectedValue(new PaymentGatewayError('declined', false));
+
+    await expect(
+      useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner),
+    ).rejects.toBeInstanceOf(PaymentChargeFailedError);
+
+    // No money moved: free the slot so the order stays payable; no PROCESSING write, no audit.
+    expect(payments.updateStatus).toHaveBeenCalledWith({
+      id: 'pay-1',
+      status: PaymentStatus.CANCELLED,
+    });
+    expect(payments.markCharged).not.toHaveBeenCalled();
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+
+  it('holds the slot and flags reconciliation on an ambiguous gateway failure', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder);
+    payments.findActiveByOrderId.mockResolvedValue(null);
+    payments.create.mockResolvedValue(makePayment(PaymentStatus.PENDING));
+    gateway.charge.mockRejectedValue(new PaymentGatewayError('timeout', true));
+
+    await expect(
+      useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner),
+    ).rejects.toMatchObject({ ambiguous: true });
+
+    // Outcome unknown: keep it PROCESSING (slot held, sweeper-safe) and record reconciliation.
+    expect(payments.updateStatus).toHaveBeenCalledWith({
+      id: 'pay-1',
+      status: PaymentStatus.PROCESSING,
+    });
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED }),
+    );
+    expect(payments.markCharged).not.toHaveBeenCalled();
+  });
+
+  it('treats an unexpected (non-gateway) error as ambiguous and holds the slot', async () => {
+    orders.findForPayment.mockResolvedValue(payableOrder);
+    payments.findActiveByOrderId.mockResolvedValue(null);
+    payments.create.mockResolvedValue(makePayment(PaymentStatus.PENDING));
+    gateway.charge.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      useCase.execute({ orderId: 'order-1', method: PaymentMethod.PIX }, owner),
+    ).rejects.toMatchObject({ ambiguous: true });
+
+    expect(payments.updateStatus).toHaveBeenCalledWith({
+      id: 'pay-1',
+      status: PaymentStatus.PROCESSING,
+    });
+  });
+});

--- a/src/modules/payments/application/use-cases/create-payment.use-case.ts
+++ b/src/modules/payments/application/use-cases/create-payment.use-case.ts
@@ -1,0 +1,197 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import Big from 'big.js';
+import { UserRole } from '@modules/identity/domain/value-objects/user-role';
+import {
+  ORDER_FOR_PAYMENT,
+  type OrderForPayment,
+} from '@modules/orders/application/ports/order-for-payment.port';
+import {
+  AUDIT_LOGGER,
+  type AuditLogger,
+  type AuditLogInput,
+} from '@modules/audit/application/ports/audit-logger.port';
+import { AUDIT_ACTIONS } from '@modules/audit/domain/audit-actions';
+import { Payment } from '../../domain/entities/payment.entity';
+import type { PaymentMethod } from '../../domain/value-objects/payment-method';
+import { PaymentStatus } from '../../domain/value-objects/payment-status';
+import {
+  PAYMENT_REPOSITORY,
+  type PaymentRepository,
+} from '../../domain/repositories/payment.repository';
+import {
+  PAYMENT_GATEWAY,
+  PaymentGatewayError,
+  type ChargeResult,
+  type PaymentGateway,
+} from '../ports/payment-gateway.port';
+import { OrderNotFoundError } from '../errors/order-not-found.error';
+import { OrderNotPayableError } from '../errors/order-not-payable.error';
+import { PaymentChargeFailedError } from '../errors/payment-charge-failed.error';
+import type { PaymentRequester } from './find-payment-by-order.use-case';
+
+export interface CreatePaymentCommand {
+  orderId: string;
+  method: PaymentMethod;
+}
+
+@Injectable()
+export class CreatePaymentUseCase {
+  private readonly logger = new Logger(CreatePaymentUseCase.name);
+
+  constructor(
+    @Inject(PAYMENT_REPOSITORY)
+    private readonly payments: PaymentRepository,
+    @Inject(PAYMENT_GATEWAY)
+    private readonly gateway: PaymentGateway,
+    @Inject(ORDER_FOR_PAYMENT)
+    private readonly orders: OrderForPayment,
+    @Inject(AUDIT_LOGGER)
+    private readonly audit: AuditLogger,
+  ) {}
+
+  async execute(command: CreatePaymentCommand, requester: PaymentRequester): Promise<Payment> {
+    const order = await this.orders.findForPayment(command.orderId);
+    if (!order) {
+      throw new OrderNotFoundError(`Order ${command.orderId} was not found.`);
+    }
+
+    // Customer pays only their own order; staff pays any. Non-owner gets the same
+    // 404 as missing, so it never leaks that the order exists.
+    if (requester.role === UserRole.CUSTOMER && order.customerId !== requester.id) {
+      throw new OrderNotFoundError(`Order ${command.orderId} was not found.`);
+    }
+
+    if (!order.isAwaitingPayment) {
+      throw new OrderNotPayableError(`Order ${command.orderId} is not awaiting payment.`);
+    }
+
+    // Pre-check for a nicer error; the unique index in `create` is the real race guard.
+    const active = await this.payments.findActiveByOrderId(command.orderId);
+    if (active) {
+      throw new OrderNotPayableError(
+        `Order ${command.orderId} already has a payment in progress or settled.`,
+      );
+    }
+
+    // Reserve before charging: the "one live attempt per order" index makes a concurrent
+    // reserve fail here (P2002), so the gateway is charged once. Amount comes from the
+    // order total, never from the request body.
+    const reserved = await this.payments.create({
+      orderId: command.orderId,
+      amount: order.totalAmount,
+      method: command.method,
+      status: PaymentStatus.PENDING,
+      extTransactionId: null,
+    });
+
+    let result: ChargeResult;
+    try {
+      result = await this.gateway.charge(new Big(order.totalAmount), {
+        orderId: command.orderId,
+        idempotencyKey: reserved.id,
+      });
+    } catch (err) {
+      throw await this.handleChargeFailure(err, command.orderId, reserved.id, requester.id);
+    }
+
+    // Save as PROCESSING; the webhook delivers the final APPROVED/REFUSED status.
+    let payment: Payment;
+    try {
+      payment = await this.payments.markCharged({
+        id: reserved.id,
+        status: PaymentStatus.PROCESSING,
+        extTransactionId: result.extTransactionId,
+        gatewayRequest: { amount: order.totalAmount, idempotencyKey: reserved.id },
+        gatewayResponse: result.raw,
+      });
+    } catch (err) {
+      // Charge succeeded but recording it failed: without the extTransactionId the webhook
+      // can never match this attempt. Best-effort move it to PROCESSING so the sweeper (which
+      // only cancels PENDING reservations) cannot free its slot and let a retry double-charge;
+      // the slot stays held for reconciliation. An Outbox is the real fix (charge + persist
+      // atomically); until then, flag the orphan so ops can reconcile from the gateway id.
+      await this.holdForReconciliation(reserved.id);
+      await this.logBestEffort({
+        userId: requester.id,
+        action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED,
+        entity: 'Payment',
+        entityId: reserved.id,
+        metadata: {
+          orderId: command.orderId,
+          extTransactionId: result.extTransactionId,
+          reason: 'charge succeeded but persisting the PROCESSING status failed',
+        },
+      });
+      throw err;
+    }
+
+    // Payment is already charged; a failed audit write must not 500 the caller.
+    await this.logBestEffort({
+      userId: requester.id,
+      action: AUDIT_ACTIONS.PAYMENT_CREATED,
+      entity: 'Payment',
+      entityId: payment.id,
+      metadata: { orderId: command.orderId, amount: order.totalAmount, method: command.method },
+    });
+
+    return payment;
+  }
+
+  private async logBestEffort(input: AuditLogInput): Promise<void> {
+    try {
+      await this.audit.log(input);
+    } catch (err) {
+      this.logger.error(`Failed to write audit ${input.action} for ${input.entityId}`, err);
+    }
+  }
+
+  // Best-effort: hold a charged-but-unrecorded attempt's slot by moving it to PROCESSING,
+  // which the sweeper leaves alone. If even this write fails the attempt stays PENDING and the
+  // reconcile audit log is the only safety net.
+  private async holdForReconciliation(paymentId: string): Promise<void> {
+    try {
+      await this.payments.updateStatus({ id: paymentId, status: PaymentStatus.PROCESSING });
+    } catch (err) {
+      this.logger.error(`Failed to hold payment ${paymentId} for reconciliation`, err);
+    }
+  }
+
+  /**
+   * Resolves a failed charge into the attempt's next state and the error to surface.
+   * Definite failure: no money moved, so cancel the attempt and free its slot for retry.
+   * Ambiguous failure (e.g. timeout): money may have moved, so move the attempt to
+   * PROCESSING (the sweeper leaves PROCESSING alone) and flag it for reconciliation; the
+   * held slot blocks a blind retry, so the caller cannot double-charge. Returns the error
+   * to throw so the caller's control flow ends at the `throw`.
+   */
+  private async handleChargeFailure(
+    err: unknown,
+    orderId: string,
+    paymentId: string,
+    userId: string,
+  ): Promise<PaymentChargeFailedError> {
+    // Only free the slot when the gateway explicitly says no money moved. Everything else
+    // (an ambiguous gateway failure, or any unexpected error) is treated as ambiguous and
+    // kept for reconciliation - never auto-freed, so we cannot double-charge.
+    const definite = err instanceof PaymentGatewayError && !err.ambiguous;
+
+    if (definite) {
+      await this.payments.updateStatus({ id: paymentId, status: PaymentStatus.CANCELLED });
+    } else {
+      await this.payments.updateStatus({ id: paymentId, status: PaymentStatus.PROCESSING });
+      await this.logBestEffort({
+        userId,
+        action: AUDIT_ACTIONS.PAYMENT_RECONCILE_REQUIRED,
+        entity: 'Payment',
+        entityId: paymentId,
+        metadata: { orderId, reason: 'charge failed with an unknown outcome' },
+      });
+    }
+
+    return new PaymentChargeFailedError(
+      `Charging order ${orderId} failed${definite ? '' : ' with an unknown outcome'}.`,
+      !definite,
+      { cause: err },
+    );
+  }
+}

--- a/src/modules/payments/application/use-cases/expire-stale-payments.use-case.spec.ts
+++ b/src/modules/payments/application/use-cases/expire-stale-payments.use-case.spec.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { ExpireStalePaymentsUseCase } from './expire-stale-payments.use-case';
+import type { PaymentRepository } from '../../domain/repositories/payment.repository';
+
+describe('ExpireStalePaymentsUseCase', () => {
+  let cancelStaleReservations: jest.MockedFunction<PaymentRepository['cancelStaleReservations']>;
+  let useCase: ExpireStalePaymentsUseCase;
+
+  beforeEach(() => {
+    cancelStaleReservations = jest.fn() as jest.MockedFunction<
+      PaymentRepository['cancelStaleReservations']
+    >;
+    const repo = { cancelStaleReservations } as unknown as PaymentRepository;
+    useCase = new ExpireStalePaymentsUseCase(repo);
+  });
+
+  it('cancels reservations older than now minus the ttl, returning the count', async () => {
+    cancelStaleReservations.mockResolvedValue(2);
+    const now = new Date('2026-06-07T12:00:00Z');
+
+    const count = await useCase.execute(15 * 60_000, now);
+
+    expect(cancelStaleReservations).toHaveBeenCalledWith(new Date('2026-06-07T11:45:00Z'));
+    expect(count).toBe(2);
+  });
+});

--- a/src/modules/payments/application/use-cases/expire-stale-payments.use-case.ts
+++ b/src/modules/payments/application/use-cases/expire-stale-payments.use-case.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  PAYMENT_REPOSITORY,
+  type PaymentRepository,
+} from '../../domain/repositories/payment.repository';
+
+@Injectable()
+export class ExpireStalePaymentsUseCase {
+  constructor(
+    @Inject(PAYMENT_REPOSITORY)
+    private readonly payments: PaymentRepository,
+  ) {}
+
+  /**
+   * Cancels reservations abandoned before the gateway was charged (still PENDING, never
+   * charged) older than `olderThanMs`, freeing their live-attempt slot. Only safe because
+   * the repository never sweeps PROCESSING attempts, where money may have moved. Returns
+   * how many were cancelled. `now` is injectable so tests control the clock.
+   */
+  async execute(olderThanMs: number, now: Date = new Date()): Promise<number> {
+    const cutoff = new Date(now.getTime() - olderThanMs);
+    return this.payments.cancelStaleReservations(cutoff);
+  }
+}

--- a/src/modules/payments/application/use-cases/find-payment-by-order.use-case.spec.ts
+++ b/src/modules/payments/application/use-cases/find-payment-by-order.use-case.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
+import { FindPaymentByOrderUseCase } from './find-payment-by-order.use-case';
+import type { PaymentRepository } from '../../domain/repositories/payment.repository';
+import type { OrderForPayment } from '@modules/orders/application/ports/order-for-payment.port';
+import { UserRole } from '@modules/identity/domain/value-objects/user-role';
+import { Payment } from '../../domain/entities/payment.entity';
+import { PaymentMethod } from '../../domain/value-objects/payment-method';
+import { PaymentStatus } from '../../domain/value-objects/payment-status';
+import { PaymentNotFoundError } from '../errors/payment-not-found.error';
+
+const makePayment = (): Payment =>
+  new Payment(
+    'pay-1',
+    'order-1',
+    new Big('25.00'),
+    PaymentMethod.PIX,
+    PaymentStatus.APPROVED,
+    'tx-1',
+    new Date(),
+    new Date(),
+  );
+
+const orderView = {
+  id: 'order-1',
+  isAwaitingPayment: false,
+  totalAmount: '25.00',
+  customerId: 'cust-1',
+};
+
+describe('FindPaymentByOrderUseCase', () => {
+  let payments: jest.Mocked<PaymentRepository>;
+  let orders: jest.Mocked<OrderForPayment>;
+  let useCase: FindPaymentByOrderUseCase;
+
+  beforeEach(() => {
+    payments = {
+      create: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findCurrentByOrderId: jest.fn(),
+      findByExtTransactionId: jest.fn(),
+      markCharged: jest.fn(),
+      updateStatus: jest.fn(),
+    } as unknown as jest.Mocked<PaymentRepository>;
+    orders = {
+      findForPayment: jest.fn(),
+      confirmAfterPayment: jest.fn(),
+    } as unknown as jest.Mocked<OrderForPayment>;
+
+    useCase = new FindPaymentByOrderUseCase(payments, orders);
+  });
+
+  it('returns the payment to the order owner', async () => {
+    payments.findCurrentByOrderId.mockResolvedValue(makePayment());
+    orders.findForPayment.mockResolvedValue(orderView);
+
+    const result = await useCase.execute('order-1', { id: 'cust-1', role: UserRole.CUSTOMER });
+
+    expect(result.id).toBe('pay-1');
+  });
+
+  it('returns the payment to staff regardless of ownership', async () => {
+    payments.findCurrentByOrderId.mockResolvedValue(makePayment());
+    orders.findForPayment.mockResolvedValue(orderView);
+
+    const result = await useCase.execute('order-1', { id: 'staff-1', role: UserRole.MANAGER });
+
+    expect(result.id).toBe('pay-1');
+  });
+
+  it('hides another customer payment with a 404', async () => {
+    payments.findCurrentByOrderId.mockResolvedValue(makePayment());
+    orders.findForPayment.mockResolvedValue(orderView);
+
+    await expect(
+      useCase.execute('order-1', { id: 'intruder', role: UserRole.CUSTOMER }),
+    ).rejects.toBeInstanceOf(PaymentNotFoundError);
+  });
+
+  it('throws PaymentNotFoundError when the order has no payment (404)', async () => {
+    payments.findCurrentByOrderId.mockResolvedValue(null);
+    orders.findForPayment.mockResolvedValue(orderView);
+
+    await expect(
+      useCase.execute('order-1', { id: 'cust-1', role: UserRole.CUSTOMER }),
+    ).rejects.toBeInstanceOf(PaymentNotFoundError);
+  });
+});

--- a/src/modules/payments/application/use-cases/find-payment-by-order.use-case.ts
+++ b/src/modules/payments/application/use-cases/find-payment-by-order.use-case.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { UserRole } from '@modules/identity/domain/value-objects/user-role';
+import {
+  ORDER_FOR_PAYMENT,
+  type OrderForPayment,
+} from '@modules/orders/application/ports/order-for-payment.port';
+import { Payment } from '../../domain/entities/payment.entity';
+import {
+  PAYMENT_REPOSITORY,
+  type PaymentRepository,
+} from '../../domain/repositories/payment.repository';
+import { PaymentNotFoundError } from '../errors/payment-not-found.error';
+
+/** The authenticated principal asking for the payment, resolved by the HTTP layer. */
+export interface PaymentRequester {
+  id: string;
+  role: UserRole;
+}
+
+@Injectable()
+export class FindPaymentByOrderUseCase {
+  constructor(
+    @Inject(PAYMENT_REPOSITORY)
+    private readonly payments: PaymentRepository,
+    @Inject(ORDER_FOR_PAYMENT)
+    private readonly orders: OrderForPayment,
+  ) {}
+
+  async execute(orderId: string, requester: PaymentRequester): Promise<Payment> {
+    // Independent reads, so run them together.
+    const [payment, order] = await Promise.all([
+      this.payments.findCurrentByOrderId(orderId),
+      this.orders.findForPayment(orderId),
+    ]);
+
+    // Customer sees only their own order's payment; staff sees any. Same 404 for missing
+    // and not-yours, so existence is never leaked.
+    const hiddenFromCustomer =
+      requester.role === UserRole.CUSTOMER && order?.customerId !== requester.id;
+
+    if (!payment || !order || hiddenFromCustomer) {
+      throw new PaymentNotFoundError(`No payment was found for order ${orderId}.`);
+    }
+
+    return payment;
+  }
+}

--- a/src/modules/payments/domain/entities/payment.entity.ts
+++ b/src/modules/payments/domain/entities/payment.entity.ts
@@ -1,0 +1,16 @@
+import type Big from 'big.js';
+import type { PaymentMethod } from '../value-objects/payment-method';
+import type { PaymentStatus } from '../value-objects/payment-status';
+
+export class Payment {
+  constructor(
+    public readonly id: string,
+    public readonly orderId: string,
+    public readonly amount: Big,
+    public readonly method: PaymentMethod,
+    public readonly status: PaymentStatus,
+    public readonly extTransactionId: string | null,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+}

--- a/src/modules/payments/domain/repositories/payment.repository.ts
+++ b/src/modules/payments/domain/repositories/payment.repository.ts
@@ -1,0 +1,63 @@
+import type { TransactionContext } from '@shared/transaction/transaction-runner.port';
+import { Payment } from '../entities/payment.entity';
+import type { PaymentMethod } from '../value-objects/payment-method';
+import { PaymentStatus } from '../value-objects/payment-status';
+
+export interface CreatePaymentInput {
+  orderId: string;
+  amount: string;
+  method: PaymentMethod;
+  status: PaymentStatus;
+  extTransactionId: string | null;
+  gatewayResponse?: Record<string, unknown>;
+}
+
+/** Attaches the gateway's outcome to a reserved attempt once the charge returns. */
+export interface MarkChargedInput {
+  id: string;
+  status: PaymentStatus;
+  extTransactionId: string;
+  gatewayRequest?: Record<string, unknown>;
+  gatewayResponse?: Record<string, unknown>;
+}
+
+export interface UpdatePaymentStatusInput {
+  id: string;
+  status: PaymentStatus;
+}
+
+export interface SettlePaymentInput {
+  id: string;
+  status: typeof PaymentStatus.APPROVED | typeof PaymentStatus.REFUSED;
+}
+
+export interface PaymentRepository {
+  /**
+   * Inserts a payment attempt. The partial unique index ("one live attempt per
+   * order") makes a concurrent second insert fail with P2002, which the adapter
+   * maps to `OrderNotPayableError` - this is the real double-charge guard.
+   */
+  create(input: CreatePaymentInput, tx?: TransactionContext): Promise<Payment>;
+  /** The single live attempt for an order (PENDING/PROCESSING/APPROVED), if any. */
+  findActiveByOrderId(orderId: string): Promise<Payment | null>;
+  /** The most recent attempt for an order, regardless of status (for the GET endpoint). */
+  findCurrentByOrderId(orderId: string): Promise<Payment | null>;
+  findByExtTransactionId(extTransactionId: string): Promise<Payment | null>;
+  markCharged(input: MarkChargedInput, tx?: TransactionContext): Promise<Payment>;
+  updateStatus(input: UpdatePaymentStatusInput, tx?: TransactionContext): Promise<Payment>;
+  /**
+   * Settles a still-settleable attempt (PENDING/PROCESSING) to APPROVED/REFUSED with an
+   * optimistic guard. Returns `null` when no row matched - another webhook delivery already
+   * settled it - so the caller can treat the redelivery as an idempotent no-op.
+   */
+  settle(input: SettlePaymentInput, tx?: TransactionContext): Promise<Payment | null>;
+  /**
+   * Cancels abandoned reservations: still PENDING, never charged (no extTransactionId) and
+   * older than `olderThan`. Frees their live-attempt slot so the order can be paid again.
+   * Deliberately never touches PROCESSING attempts (charge may have moved money) - those
+   * need reconciliation, not auto-cancel. Returns how many rows were cancelled.
+   */
+  cancelStaleReservations(olderThan: Date): Promise<number>;
+}
+
+export const PAYMENT_REPOSITORY = Symbol('PaymentRepository');

--- a/src/modules/payments/domain/value-objects/payment-method.ts
+++ b/src/modules/payments/domain/value-objects/payment-method.ts
@@ -1,0 +1,9 @@
+export const PaymentMethod = {
+  CREDIT_CARD: 'CREDIT_CARD',
+  DEBIT_CARD: 'DEBIT_CARD',
+  PIX: 'PIX',
+  CASH: 'CASH',
+  VOUCHER: 'VOUCHER',
+} as const;
+
+export type PaymentMethod = (typeof PaymentMethod)[keyof typeof PaymentMethod];

--- a/src/modules/payments/domain/value-objects/payment-status.ts
+++ b/src/modules/payments/domain/value-objects/payment-status.ts
@@ -1,0 +1,29 @@
+export const PaymentStatus = {
+  PENDING: 'PENDING',
+  PROCESSING: 'PROCESSING',
+  APPROVED: 'APPROVED',
+  REFUSED: 'REFUSED',
+  CANCELLED: 'CANCELLED',
+} as const;
+
+export type PaymentStatus = (typeof PaymentStatus)[keyof typeof PaymentStatus];
+
+/**
+ * Statuses that occupy the "one live attempt per order" slot. Kept in sync with the
+ * partial unique index in the payments migration - a refused/cancelled attempt frees
+ * the slot so the order can be paid again.
+ */
+export const LIVE_PAYMENT_STATUSES = [
+  PaymentStatus.PENDING,
+  PaymentStatus.PROCESSING,
+  PaymentStatus.APPROVED,
+] as const;
+
+/**
+ * Non-terminal statuses a gateway webhook may settle from. Used as the WHERE guard of the
+ * conditional settle so concurrent webhook redeliveries apply the outcome exactly once.
+ */
+export const SETTLEABLE_PAYMENT_STATUSES = [
+  PaymentStatus.PENDING,
+  PaymentStatus.PROCESSING,
+] as const;

--- a/src/modules/payments/infrastructure/gateway/mock-payment-gateway.spec.ts
+++ b/src/modules/payments/infrastructure/gateway/mock-payment-gateway.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from '@jest/globals';
+import Big from 'big.js';
+import { MockPaymentGateway } from './mock-payment-gateway';
+import { PaymentGatewayError } from '../../application/ports/payment-gateway.port';
+import { PaymentStatus } from '../../domain/value-objects/payment-status';
+
+describe('MockPaymentGateway', () => {
+  const request = { orderId: 'order-1', idempotencyKey: 'pay-1' };
+
+  it('approves a charge and returns a transaction id', async () => {
+    const gateway = new MockPaymentGateway();
+
+    const result = await gateway.charge(new Big('25.00'), request);
+
+    expect(result.status).toBe(PaymentStatus.APPROVED);
+    expect(result.extTransactionId).toEqual(expect.any(String));
+    expect(result.extTransactionId.length).toBeGreaterThan(0);
+  });
+
+  it('refuses the magic test amount 13.13', async () => {
+    const gateway = new MockPaymentGateway();
+
+    const result = await gateway.charge(new Big('13.13'), request);
+
+    expect(result.status).toBe(PaymentStatus.REFUSED);
+  });
+
+  it('fails definitively (no money moved) for the magic amount 66.66', async () => {
+    const gateway = new MockPaymentGateway();
+
+    await expect(gateway.charge(new Big('66.66'), request)).rejects.toMatchObject({
+      ambiguous: false,
+    });
+    await expect(gateway.charge(new Big('66.66'), request)).rejects.toBeInstanceOf(
+      PaymentGatewayError,
+    );
+  });
+
+  it('fails ambiguously (unknown outcome) for the magic amount 77.77', async () => {
+    const gateway = new MockPaymentGateway();
+
+    await expect(gateway.charge(new Big('77.77'), request)).rejects.toMatchObject({
+      ambiguous: true,
+    });
+  });
+
+  it('is idempotent: the same key returns the original result without re-charging', async () => {
+    const gateway = new MockPaymentGateway();
+
+    const first = await gateway.charge(new Big('25.00'), request);
+    const second = await gateway.charge(new Big('25.00'), request);
+
+    expect(second).toEqual(first);
+    expect(second.extTransactionId).toBe(first.extTransactionId);
+  });
+
+  it('treats different keys as distinct charges', async () => {
+    const gateway = new MockPaymentGateway();
+
+    const first = await gateway.charge(new Big('25.00'), {
+      orderId: 'order-1',
+      idempotencyKey: 'a',
+    });
+    const second = await gateway.charge(new Big('25.00'), {
+      orderId: 'order-1',
+      idempotencyKey: 'b',
+    });
+
+    expect(second.extTransactionId).not.toBe(first.extTransactionId);
+  });
+});

--- a/src/modules/payments/infrastructure/gateway/mock-payment-gateway.ts
+++ b/src/modules/payments/infrastructure/gateway/mock-payment-gateway.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import Big from 'big.js';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import {
+  PaymentGatewayError,
+  type ChargeRequest,
+  type ChargeResult,
+  type PaymentGateway,
+} from '../../application/ports/payment-gateway.port';
+import { PaymentStatus } from '../../domain/value-objects/payment-status';
+
+/** Charging exactly this amount is refused (settled via webhook), to drive the refusal path. */
+const TEST_REFUSAL_AMOUNT = new Big('13.13');
+/** Charging this amount fails outright with no money moved (definite gateway failure). */
+const TEST_DEFINITE_FAILURE_AMOUNT = new Big('66.66');
+/** Charging this amount fails with an unknown outcome (e.g. a timeout): money may have moved. */
+const TEST_AMBIGUOUS_FAILURE_AMOUNT = new Big('77.77');
+
+const SIMULATED_LATENCY_MS = 200;
+
+@Injectable()
+export class MockPaymentGateway implements PaymentGateway {
+  /** Stands in for the PSP's idempotency store: same key -> same original result. */
+  private readonly seen = new Map<string, ChargeResult>();
+
+  async charge(amount: Big, request: ChargeRequest): Promise<ChargeResult> {
+    const cached = this.seen.get(request.idempotencyKey);
+    if (cached) {
+      return cached;
+    }
+
+    await delay(SIMULATED_LATENCY_MS);
+
+    if (amount.eq(TEST_DEFINITE_FAILURE_AMOUNT)) {
+      throw new PaymentGatewayError('Mock gateway: charge declined before any capture.', false);
+    }
+    if (amount.eq(TEST_AMBIGUOUS_FAILURE_AMOUNT)) {
+      throw new PaymentGatewayError(
+        'Mock gateway: charge timed out with an unknown outcome.',
+        true,
+      );
+    }
+
+    const approved = !amount.eq(TEST_REFUSAL_AMOUNT);
+    const status = approved ? PaymentStatus.APPROVED : PaymentStatus.REFUSED;
+
+    const result: ChargeResult = {
+      extTransactionId: `mock_${randomUUID()}`,
+      status,
+      raw: { amount: amount.toFixed(2), status, orderId: request.orderId },
+    };
+
+    this.seen.set(request.idempotencyKey, result);
+    return result;
+  }
+}

--- a/src/modules/payments/infrastructure/http/controllers/payments.controller.spec.ts
+++ b/src/modules/payments/infrastructure/http/controllers/payments.controller.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Big from 'big.js';
+import { PaymentsController } from './payments.controller';
+import { CreatePaymentUseCase } from '@modules/payments/application/use-cases/create-payment.use-case';
+import { ConfirmPaymentUseCase } from '@modules/payments/application/use-cases/confirm-payment.use-case';
+import { FindPaymentByOrderUseCase } from '@modules/payments/application/use-cases/find-payment-by-order.use-case';
+import { Payment } from '@modules/payments/domain/entities/payment.entity';
+import { PaymentMethod } from '@modules/payments/domain/value-objects/payment-method';
+import { PaymentStatus } from '@modules/payments/domain/value-objects/payment-status';
+import { UserRole } from '@modules/identity/domain/value-objects/user-role';
+import type { JwtPayload } from '@shared/auth/jwt-payload.type';
+
+const makePayment = (status: PaymentStatus = PaymentStatus.PROCESSING): Payment =>
+  new Payment(
+    'pay-1',
+    'order-1',
+    new Big('25.00'),
+    PaymentMethod.PIX,
+    status,
+    'tx-1',
+    new Date(),
+    new Date(),
+  );
+
+const user: JwtPayload = {
+  sub: 'user-1',
+  username: 'tester',
+  role: UserRole.CUSTOMER,
+  iat: 0,
+  exp: 0,
+};
+
+describe('PaymentsController', () => {
+  let controller: PaymentsController;
+  let createPayment: jest.Mocked<CreatePaymentUseCase>;
+  let confirmPayment: jest.Mocked<ConfirmPaymentUseCase>;
+  let findPaymentByOrder: jest.Mocked<FindPaymentByOrderUseCase>;
+
+  beforeEach(() => {
+    createPayment = { execute: jest.fn() } as unknown as jest.Mocked<CreatePaymentUseCase>;
+    confirmPayment = { execute: jest.fn() } as unknown as jest.Mocked<ConfirmPaymentUseCase>;
+    findPaymentByOrder = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<FindPaymentByOrderUseCase>;
+
+    controller = new PaymentsController(createPayment, confirmPayment, findPaymentByOrder);
+  });
+
+  it('maps a created payment to a response dto with money as a string', async () => {
+    createPayment.execute.mockResolvedValue(makePayment());
+
+    const result = await controller.create({ orderId: 'order-1', method: PaymentMethod.PIX }, user);
+
+    expect(createPayment.execute).toHaveBeenCalledWith(
+      { orderId: 'order-1', method: PaymentMethod.PIX },
+      { id: 'user-1', role: UserRole.CUSTOMER },
+    );
+    expect(result.amount).toBe('25.00');
+    expect(result.status).toBe(PaymentStatus.PROCESSING);
+  });
+
+  it('acks the webhook with 200 and forwards the fields to confirm', async () => {
+    confirmPayment.execute.mockResolvedValue(makePayment(PaymentStatus.APPROVED));
+
+    const result = await controller.webhook({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      amount: '25.00',
+    });
+
+    expect(confirmPayment.execute).toHaveBeenCalledWith({
+      extTransactionId: 'tx-1',
+      status: PaymentStatus.APPROVED,
+      amount: '25.00',
+    });
+    // The gateway gets a uniform ack, never our internal payment representation.
+    expect(result).toEqual({ received: true });
+  });
+
+  it('returns a payment by order id, passing the requester through', async () => {
+    findPaymentByOrder.execute.mockResolvedValue(makePayment(PaymentStatus.APPROVED));
+
+    const result = await controller.findByOrder({ orderId: 'order-1' }, user);
+
+    expect(findPaymentByOrder.execute).toHaveBeenCalledWith('order-1', {
+      id: 'user-1',
+      role: UserRole.CUSTOMER,
+    });
+    expect(result.orderId).toBe('order-1');
+  });
+});

--- a/src/modules/payments/infrastructure/http/controllers/payments.controller.ts
+++ b/src/modules/payments/infrastructure/http/controllers/payments.controller.ts
@@ -1,0 +1,95 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
+import { CurrentUser } from '@shared/auth/current-user.decorator';
+import { Public } from '@shared/auth/public.decorator';
+import type { JwtPayload } from '@shared/auth/jwt-payload.type';
+import { CreatePaymentUseCase } from '@modules/payments/application/use-cases/create-payment.use-case';
+import { ConfirmPaymentUseCase } from '@modules/payments/application/use-cases/confirm-payment.use-case';
+import { FindPaymentByOrderUseCase } from '@modules/payments/application/use-cases/find-payment-by-order.use-case';
+import { CreatePaymentDto } from '../dto/create-payment.dto';
+import { PaymentWebhookDto } from '../dto/payment-webhook.dto';
+import { PaymentWebhookAckDto } from '../dto/payment-webhook-ack.dto';
+import { OrderPaymentParamDto } from '../dto/payment-params.dto';
+import { PaymentResponseDto } from '../dto/payment-response.dto';
+import { PaymentWebhookGuard } from '../guards/payment-webhook.guard';
+
+@ApiTags('payments')
+@Controller()
+export class PaymentsController {
+  constructor(
+    private readonly createPayment: CreatePaymentUseCase,
+    private readonly confirmPayment: ConfirmPaymentUseCase,
+    private readonly findPaymentByOrder: FindPaymentByOrderUseCase,
+  ) {}
+
+  @Post('payments')
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a payment for an order and charge the gateway.' })
+  @ApiCreatedResponse({ type: PaymentResponseDto })
+  @ApiNotFoundResponse({ description: 'Order not found.' })
+  @ApiUnprocessableEntityResponse({ description: 'Order is not awaiting payment or already paid.' })
+  async create(
+    @Body() body: CreatePaymentDto,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<PaymentResponseDto> {
+    const payment = await this.createPayment.execute(
+      { orderId: body.orderId, method: body.method },
+      { id: user.sub, role: user.role },
+    );
+    return PaymentResponseDto.fromEntity(payment);
+  }
+
+  @Post('payments/webhook')
+  @Public()
+  @UseGuards(PaymentWebhookGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Gateway webhook: settle a payment and advance its order.' })
+  @ApiOkResponse({ type: PaymentWebhookAckDto })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid webhook signature.' })
+  async webhook(@Body() body: PaymentWebhookDto): Promise<PaymentWebhookAckDto> {
+    // Always ack with 200: the gateway only cares about the status code, and a non-2xx on
+    // an unknown/duplicate event would trigger endless redelivery. confirmPayment records
+    // anything it cannot settle for reconciliation.
+    await this.confirmPayment.execute({
+      extTransactionId: body.extTransactionId,
+      status: body.status,
+      amount: body.amount,
+    });
+    return { received: true };
+  }
+
+  @Get('orders/:orderId/payment')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get the payment of an order. Customers may only see their own.' })
+  @ApiOkResponse({ type: PaymentResponseDto })
+  @ApiNotFoundResponse({ description: 'Order has no payment, or is not visible to the requester.' })
+  async findByOrder(
+    @Param() { orderId }: OrderPaymentParamDto,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<PaymentResponseDto> {
+    const payment = await this.findPaymentByOrder.execute(orderId, {
+      id: user.sub,
+      role: user.role,
+    });
+    return PaymentResponseDto.fromEntity(payment);
+  }
+}

--- a/src/modules/payments/infrastructure/http/dto/create-payment.dto.ts
+++ b/src/modules/payments/infrastructure/http/dto/create-payment.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsUUID } from 'class-validator';
+import { PaymentMethod } from '@modules/payments/domain/value-objects/payment-method';
+
+export class CreatePaymentDto {
+  @ApiProperty({ format: 'uuid', description: 'Order being paid.' })
+  @IsUUID()
+  orderId!: string;
+
+  @ApiProperty({ enum: PaymentMethod, description: 'Tender used to pay.' })
+  @IsEnum(PaymentMethod)
+  method!: PaymentMethod;
+}

--- a/src/modules/payments/infrastructure/http/dto/payment-params.dto.ts
+++ b/src/modules/payments/infrastructure/http/dto/payment-params.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class OrderPaymentParamDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000', format: 'uuid' })
+  @IsUUID()
+  orderId!: string;
+}

--- a/src/modules/payments/infrastructure/http/dto/payment-response.dto.ts
+++ b/src/modules/payments/infrastructure/http/dto/payment-response.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Payment } from '@modules/payments/domain/entities/payment.entity';
+import { PaymentMethod } from '@modules/payments/domain/value-objects/payment-method';
+import { PaymentStatus } from '@modules/payments/domain/value-objects/payment-status';
+
+export class PaymentResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  readonly id!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  readonly orderId!: string;
+
+  @ApiProperty({ example: '25.00', description: 'Money serialized as a decimal string.' })
+  readonly amount!: string;
+
+  @ApiProperty({ enum: PaymentMethod })
+  readonly method!: PaymentMethod;
+
+  @ApiProperty({ enum: PaymentStatus })
+  readonly status!: PaymentStatus;
+
+  @ApiProperty({ nullable: true, description: "The gateway's transaction id, if assigned." })
+  readonly extTransactionId!: string | null;
+
+  @ApiProperty()
+  readonly createdAt!: Date;
+
+  @ApiProperty()
+  readonly updatedAt!: Date;
+
+  static fromEntity(payment: Payment): PaymentResponseDto {
+    return Object.assign(new PaymentResponseDto(), {
+      id: payment.id,
+      orderId: payment.orderId,
+      amount: payment.amount.toFixed(2),
+      method: payment.method,
+      status: payment.status,
+      extTransactionId: payment.extTransactionId,
+      createdAt: payment.createdAt,
+      updatedAt: payment.updatedAt,
+    });
+  }
+}

--- a/src/modules/payments/infrastructure/http/dto/payment-webhook-ack.dto.ts
+++ b/src/modules/payments/infrastructure/http/dto/payment-webhook-ack.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Uniform 200 acknowledgement for the gateway. We never return our internal payment
+ * representation to the gateway, and we ack even unmatched events so it stops redelivering.
+ */
+export class PaymentWebhookAckDto {
+  @ApiProperty({ example: true, description: 'The webhook was received and processed.' })
+  readonly received!: boolean;
+}

--- a/src/modules/payments/infrastructure/http/dto/payment-webhook.dto.ts
+++ b/src/modules/payments/infrastructure/http/dto/payment-webhook.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDecimal, IsIn, IsNotEmpty, IsString } from 'class-validator';
+import { PaymentStatus } from '@modules/payments/domain/value-objects/payment-status';
+
+/** Statuses a gateway webhook may deliver - a settled outcome, never an in-flight one. */
+const WEBHOOK_STATUSES = [PaymentStatus.APPROVED, PaymentStatus.REFUSED] as const;
+
+type WebhookStatus = (typeof WEBHOOK_STATUSES)[number];
+
+export class PaymentWebhookDto {
+  @ApiProperty({ description: "The gateway's transaction id returned at charge time." })
+  @IsString()
+  @IsNotEmpty()
+  extTransactionId!: string;
+
+  @ApiProperty({ enum: WEBHOOK_STATUSES, description: 'Settled outcome reported by the gateway.' })
+  @IsIn(WEBHOOK_STATUSES)
+  status!: WebhookStatus;
+
+  @ApiProperty({
+    example: '25.00',
+    description: 'Amount the gateway settled, as a decimal string; must match what we charged.',
+  })
+  @IsDecimal(
+    { decimal_digits: '0,2' },
+    { message: 'amount must be a decimal string with up to 2 decimal places' },
+  )
+  amount!: string;
+}

--- a/src/modules/payments/infrastructure/http/guards/payment-webhook.guard.spec.ts
+++ b/src/modules/payments/infrastructure/http/guards/payment-webhook.guard.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from '@jest/globals';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  buildWebhookSignature,
+  PaymentWebhookGuard,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+} from './payment-webhook.guard';
+
+const SECRET = 'top-secret';
+const body = { extTransactionId: 'tx-1', status: 'APPROVED', amount: '25.00' };
+
+const buildGuard = (configured: string | undefined): PaymentWebhookGuard =>
+  new PaymentWebhookGuard({ get: () => configured } as unknown as ConfigService);
+
+const buildContext = (
+  headers: Record<string, string | undefined>,
+  reqBody: unknown = body,
+): ExecutionContext => {
+  const request = {
+    header: (name: string): string | undefined => headers[name.toLowerCase()],
+    body: reqBody,
+  };
+  return { switchToHttp: () => ({ getRequest: () => request }) } as unknown as ExecutionContext;
+};
+
+const nowSeconds = (): string => String(Math.floor(Date.now() / 1000));
+
+const sign = (secret: string, timestamp: string, b = body): string =>
+  buildWebhookSignature(secret, {
+    timestamp,
+    extTransactionId: String(b.extTransactionId),
+    status: String(b.status),
+    amount: String(b.amount),
+  });
+
+const signedHeaders = (timestamp = nowSeconds(), secret = SECRET): Record<string, string> => ({
+  [WEBHOOK_SIGNATURE_HEADER]: sign(secret, timestamp),
+  [WEBHOOK_TIMESTAMP_HEADER]: timestamp,
+});
+
+describe('PaymentWebhookGuard', () => {
+  it('allows a request with a fresh, valid signature', () => {
+    const guard = buildGuard(SECRET);
+
+    expect(guard.canActivate(buildContext(signedHeaders()))).toBe(true);
+  });
+
+  it('rejects a request signed with the wrong secret', () => {
+    const guard = buildGuard(SECRET);
+    const ts = nowSeconds();
+    const headers = {
+      [WEBHOOK_SIGNATURE_HEADER]: sign('other', ts),
+      [WEBHOOK_TIMESTAMP_HEADER]: ts,
+    };
+
+    expect(() => guard.canActivate(buildContext(headers))).toThrow(UnauthorizedException);
+  });
+
+  it('rejects a tampered body (signature no longer matches the payload)', () => {
+    const guard = buildGuard(SECRET);
+    const headers = signedHeaders(); // signed for amount 25.00
+
+    expect(() => guard.canActivate(buildContext(headers, { ...body, amount: '30.00' }))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects a missing signature header', () => {
+    const guard = buildGuard(SECRET);
+
+    expect(() =>
+      guard.canActivate(buildContext({ [WEBHOOK_TIMESTAMP_HEADER]: nowSeconds() })),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('rejects a missing timestamp header', () => {
+    const guard = buildGuard(SECRET);
+    const ts = nowSeconds();
+
+    expect(() =>
+      guard.canActivate(buildContext({ [WEBHOOK_SIGNATURE_HEADER]: sign(SECRET, ts) })),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('rejects a stale timestamp (replay protection)', () => {
+    const guard = buildGuard(SECRET);
+    const stale = String(Math.floor(Date.now() / 1000) - 1000);
+
+    expect(() => guard.canActivate(buildContext(signedHeaders(stale)))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects when the server has no secret configured', () => {
+    const guard = buildGuard(undefined);
+
+    expect(() => guard.canActivate(buildContext(signedHeaders()))).toThrow(UnauthorizedException);
+  });
+});

--- a/src/modules/payments/infrastructure/http/guards/payment-webhook.guard.ts
+++ b/src/modules/payments/infrastructure/http/guards/payment-webhook.guard.ts
@@ -1,0 +1,91 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Request } from 'express';
+
+export const WEBHOOK_SIGNATURE_HEADER = 'x-webhook-signature';
+export const WEBHOOK_TIMESTAMP_HEADER = 'x-webhook-timestamp';
+
+/** How far the signed timestamp may drift from now, in seconds (anti-replay window). */
+const TOLERANCE_SECONDS = 300;
+
+export interface WebhookSignatureParts {
+  timestamp: string;
+  extTransactionId: string;
+  status: string;
+  amount: string;
+}
+
+/**
+ * The signing scheme, shared by the guard and any signer (tests, and later a real PSP
+ * adapter): HMAC-SHA256 over a canonical `timestamp.extTransactionId.status.amount`. The
+ * timestamp is inside the signed payload so it cannot be swapped to defeat the freshness
+ * check. Signing the fields (not the raw body) keeps the guard free of raw-body plumbing.
+ */
+export function buildWebhookSignature(secret: string, parts: WebhookSignatureParts): string {
+  const canonical = `${parts.timestamp}.${parts.extTransactionId}.${parts.status}.${parts.amount}`;
+  return createHmac('sha256', secret).update(canonical).digest('hex');
+}
+
+/**
+ * Verifies a signed gateway webhook. Replaces a static shared secret: the request must
+ * carry a fresh timestamp and a valid HMAC over the payload, so a captured request cannot
+ * be replayed and the body cannot be tampered. Fails closed when the secret is unset.
+ */
+@Injectable()
+export class PaymentWebhookGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const secret = this.config.get<string>('PAYMENT_WEBHOOK_SECRET');
+    const signature = request.header(WEBHOOK_SIGNATURE_HEADER);
+    const timestamp = request.header(WEBHOOK_TIMESTAMP_HEADER);
+
+    if (!secret || !signature || !timestamp) {
+      throw new UnauthorizedException('Missing webhook signature.');
+    }
+
+    if (!this.isFresh(timestamp)) {
+      throw new UnauthorizedException('Webhook timestamp is stale or invalid.');
+    }
+
+    // Body is still raw here (the guard runs before the validation pipe), so each field is
+    // unknown. Coerce only real strings; anything else becomes '' and fails the match, so a
+    // malformed body fails closed instead of being stringified to junk.
+    const body = (request.body ?? {}) as Record<string, unknown>;
+    const expected = buildWebhookSignature(secret, {
+      timestamp,
+      extTransactionId: this.asString(body.extTransactionId),
+      status: this.asString(body.status),
+      amount: this.asString(body.amount),
+    });
+
+    if (!this.safeEqual(signature, expected)) {
+      throw new UnauthorizedException('Invalid webhook signature.');
+    }
+
+    return true;
+  }
+
+  private isFresh(timestamp: string): boolean {
+    const ts = Number(timestamp);
+    if (!Number.isFinite(ts)) {
+      return false;
+    }
+    return Math.abs(Date.now() / 1000 - ts) <= TOLERANCE_SECONDS;
+  }
+
+  private asString(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+  }
+
+  private safeEqual(a: string, b: string): boolean {
+    const bufA = Buffer.from(a);
+    const bufB = Buffer.from(b);
+    if (bufA.length !== bufB.length) {
+      return false;
+    }
+    return timingSafeEqual(bufA, bufB);
+  }
+}

--- a/src/modules/payments/infrastructure/persistence/prisma-payment.repository.spec.ts
+++ b/src/modules/payments/infrastructure/persistence/prisma-payment.repository.spec.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Prisma } from '@prisma/client';
+import { PrismaPaymentRepository } from './prisma-payment.repository';
+import { PrismaService } from '@shared/infrastructure/prisma/prisma.service';
+import { PaymentMethod } from '@modules/payments/domain/value-objects/payment-method';
+import { PaymentStatus } from '@modules/payments/domain/value-objects/payment-status';
+import { OrderNotPayableError } from '@modules/payments/application/errors/order-not-payable.error';
+
+// Each delegate method is an async fn; `unknown` args/return keep the cast light while
+// letting mockResolvedValue accept the raw Prisma rows.
+type DelegateFn = jest.MockedFunction<(args?: unknown) => Promise<unknown>>;
+
+type PaymentDelegate = {
+  create: DelegateFn;
+  findUnique: DelegateFn;
+  findFirst: DelegateFn;
+  update: DelegateFn;
+  updateMany: DelegateFn;
+};
+
+const delegateFn = (): DelegateFn => jest.fn() as DelegateFn;
+
+const buildPrismaMock = (): { payment: PaymentDelegate } => ({
+  payment: {
+    create: delegateFn(),
+    findUnique: delegateFn(),
+    findFirst: delegateFn(),
+    update: delegateFn(),
+    updateMany: delegateFn(),
+  },
+});
+
+const rawPayment = {
+  id: 'pay-1',
+  orderId: 'order-1',
+  amount: new Prisma.Decimal('25.00'),
+  method: PaymentMethod.PIX,
+  status: PaymentStatus.PROCESSING,
+  extTransactionId: 'tx-1',
+  gatewayRequest: null,
+  gatewayResponse: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('PrismaPaymentRepository', () => {
+  let prisma: { payment: PaymentDelegate };
+  let repo: PrismaPaymentRepository;
+
+  beforeEach(() => {
+    prisma = buildPrismaMock();
+    repo = new PrismaPaymentRepository(prisma as unknown as PrismaService);
+  });
+
+  it('persists a payment and maps it to a domain entity with Big amount', async () => {
+    prisma.payment.create.mockResolvedValue(rawPayment);
+
+    const result = await repo.create({
+      orderId: 'order-1',
+      amount: '25.00',
+      method: PaymentMethod.PIX,
+      status: PaymentStatus.PENDING,
+      extTransactionId: null,
+    });
+
+    expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+    expect(result.id).toBe('pay-1');
+    expect(result.amount.toFixed(2)).toBe('25.00');
+  });
+
+  it('maps a unique-violation (P2002) to OrderNotPayableError', async () => {
+    prisma.payment.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('dup', { code: 'P2002', clientVersion: '7' }),
+    );
+
+    await expect(
+      repo.create({
+        orderId: 'order-1',
+        amount: '25.00',
+        method: PaymentMethod.PIX,
+        status: PaymentStatus.PENDING,
+        extTransactionId: null,
+      }),
+    ).rejects.toBeInstanceOf(OrderNotPayableError);
+  });
+
+  it('finds the live attempt for an order (PENDING/PROCESSING/APPROVED)', async () => {
+    prisma.payment.findFirst.mockResolvedValue(rawPayment);
+
+    const result = await repo.findActiveByOrderId('order-1');
+
+    expect(prisma.payment.findFirst).toHaveBeenCalledWith({
+      where: {
+        orderId: 'order-1',
+        status: { in: [PaymentStatus.PENDING, PaymentStatus.PROCESSING, PaymentStatus.APPROVED] },
+      },
+    });
+    expect(result?.orderId).toBe('order-1');
+  });
+
+  it('returns null when no live attempt exists for the order', async () => {
+    prisma.payment.findFirst.mockResolvedValue(null);
+
+    expect(await repo.findActiveByOrderId('order-x')).toBeNull();
+  });
+
+  it('finds the most recent attempt for an order', async () => {
+    prisma.payment.findFirst.mockResolvedValue(rawPayment);
+
+    const result = await repo.findCurrentByOrderId('order-1');
+
+    expect(prisma.payment.findFirst).toHaveBeenCalledWith({
+      where: { orderId: 'order-1' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(result?.id).toBe('pay-1');
+  });
+
+  it('finds a payment by ext transaction id via findUnique', async () => {
+    prisma.payment.findUnique.mockResolvedValue(rawPayment);
+
+    const result = await repo.findByExtTransactionId('tx-1');
+
+    expect(prisma.payment.findUnique).toHaveBeenCalledWith({
+      where: { extTransactionId: 'tx-1' },
+    });
+    expect(result?.extTransactionId).toBe('tx-1');
+  });
+
+  it('attaches the gateway outcome to a reserved attempt (markCharged)', async () => {
+    prisma.payment.update.mockResolvedValue({ ...rawPayment, status: PaymentStatus.PROCESSING });
+
+    const result = await repo.markCharged({
+      id: 'pay-1',
+      status: PaymentStatus.PROCESSING,
+      extTransactionId: 'tx-1',
+      gatewayRequest: { amount: '25.00', idempotencyKey: 'pay-1' },
+      gatewayResponse: { ok: true },
+    });
+
+    expect(prisma.payment.update).toHaveBeenCalledWith({
+      where: { id: 'pay-1' },
+      data: {
+        status: PaymentStatus.PROCESSING,
+        extTransactionId: 'tx-1',
+        gatewayRequest: { amount: '25.00', idempotencyKey: 'pay-1' },
+        gatewayResponse: { ok: true },
+      },
+    });
+    expect(result.status).toBe(PaymentStatus.PROCESSING);
+  });
+
+  it('updates a payment status', async () => {
+    prisma.payment.update.mockResolvedValue({ ...rawPayment, status: PaymentStatus.APPROVED });
+
+    const result = await repo.updateStatus({ id: 'pay-1', status: PaymentStatus.APPROVED });
+
+    expect(prisma.payment.update).toHaveBeenCalledWith({
+      where: { id: 'pay-1' },
+      data: { status: PaymentStatus.APPROVED },
+    });
+    expect(result.status).toBe(PaymentStatus.APPROVED);
+  });
+
+  describe('settle', () => {
+    it('settles a still-settleable attempt and returns the re-read payment', async () => {
+      prisma.payment.updateMany.mockResolvedValue({ count: 1 });
+      prisma.payment.findUnique.mockResolvedValue({
+        ...rawPayment,
+        status: PaymentStatus.APPROVED,
+      });
+
+      const result = await repo.settle({ id: 'pay-1', status: PaymentStatus.APPROVED });
+
+      expect(prisma.payment.updateMany).toHaveBeenCalledWith({
+        where: { id: 'pay-1', status: { in: [PaymentStatus.PENDING, PaymentStatus.PROCESSING] } },
+        data: { status: PaymentStatus.APPROVED },
+      });
+      expect(prisma.payment.findUnique).toHaveBeenCalledWith({ where: { id: 'pay-1' } });
+      expect(result?.status).toBe(PaymentStatus.APPROVED);
+    });
+
+    it('returns null without re-reading when no settleable row matched (already settled)', async () => {
+      prisma.payment.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        repo.settle({ id: 'pay-1', status: PaymentStatus.APPROVED }),
+      ).resolves.toBeNull();
+      expect(prisma.payment.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelStaleReservations', () => {
+    it('cancels only stale, never-charged PENDING reservations and returns the count', async () => {
+      prisma.payment.updateMany.mockResolvedValue({ count: 3 });
+      const cutoff = new Date('2026-01-01T00:00:00Z');
+
+      const count = await repo.cancelStaleReservations(cutoff);
+
+      // PROCESSING (possibly charged) and already-charged rows are deliberately excluded.
+      expect(prisma.payment.updateMany).toHaveBeenCalledWith({
+        where: {
+          status: PaymentStatus.PENDING,
+          extTransactionId: null,
+          createdAt: { lt: cutoff },
+        },
+        data: { status: PaymentStatus.CANCELLED },
+      });
+      expect(count).toBe(3);
+    });
+  });
+});

--- a/src/modules/payments/infrastructure/persistence/prisma-payment.repository.ts
+++ b/src/modules/payments/infrastructure/persistence/prisma-payment.repository.ts
@@ -1,0 +1,142 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, type Payment as PaymentModel } from '@prisma/client';
+import Big from 'big.js';
+import { PrismaService } from '@shared/infrastructure/prisma/prisma.service';
+import { TransactionContext } from '@shared/transaction/transaction-runner.port';
+import { Payment } from '@modules/payments/domain/entities/payment.entity';
+import {
+  CreatePaymentInput,
+  MarkChargedInput,
+  PaymentRepository,
+  SettlePaymentInput,
+  UpdatePaymentStatusInput,
+} from '@modules/payments/domain/repositories/payment.repository';
+import {
+  LIVE_PAYMENT_STATUSES,
+  PaymentStatus,
+  SETTLEABLE_PAYMENT_STATUSES,
+} from '@modules/payments/domain/value-objects/payment-status';
+import { OrderNotPayableError } from '@modules/payments/application/errors/order-not-payable.error';
+
+@Injectable()
+export class PrismaPaymentRepository implements PaymentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(input: CreatePaymentInput, tx?: TransactionContext): Promise<Payment> {
+    const db = (tx as Prisma.TransactionClient) ?? this.prisma;
+
+    try {
+      const raw = await db.payment.create({
+        data: {
+          orderId: input.orderId,
+          amount: input.amount,
+          method: input.method,
+          status: input.status,
+          extTransactionId: input.extTransactionId,
+          gatewayResponse: (input.gatewayResponse as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+        },
+      });
+      return this.toEntity(raw);
+    } catch (err) {
+      // The partial unique index (one live attempt per order) rejects a concurrent
+      // second reserve before the gateway is charged.
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        throw new OrderNotPayableError(
+          `Order ${input.orderId} already has a payment in progress or settled.`,
+          { cause: err },
+        );
+      }
+      throw err;
+    }
+  }
+
+  async findActiveByOrderId(orderId: string): Promise<Payment | null> {
+    const raw = await this.prisma.payment.findFirst({
+      where: { orderId, status: { in: [...LIVE_PAYMENT_STATUSES] } },
+    });
+    return raw ? this.toEntity(raw) : null;
+  }
+
+  async findCurrentByOrderId(orderId: string): Promise<Payment | null> {
+    const raw = await this.prisma.payment.findFirst({
+      where: { orderId },
+      orderBy: { createdAt: 'desc' },
+    });
+    return raw ? this.toEntity(raw) : null;
+  }
+
+  async findByExtTransactionId(extTransactionId: string): Promise<Payment | null> {
+    const raw = await this.prisma.payment.findUnique({ where: { extTransactionId } });
+    return raw ? this.toEntity(raw) : null;
+  }
+
+  async markCharged(input: MarkChargedInput, tx?: TransactionContext): Promise<Payment> {
+    const db = (tx as Prisma.TransactionClient) ?? this.prisma;
+
+    const raw = await db.payment.update({
+      where: { id: input.id },
+      data: {
+        status: input.status,
+        extTransactionId: input.extTransactionId,
+        gatewayRequest: (input.gatewayRequest as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+        gatewayResponse: (input.gatewayResponse as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+      },
+    });
+    return this.toEntity(raw);
+  }
+
+  async updateStatus(input: UpdatePaymentStatusInput, tx?: TransactionContext): Promise<Payment> {
+    const db = (tx as Prisma.TransactionClient) ?? this.prisma;
+
+    const raw = await db.payment.update({
+      where: { id: input.id },
+      data: { status: input.status },
+    });
+    return this.toEntity(raw);
+  }
+
+  async settle(input: SettlePaymentInput, tx?: TransactionContext): Promise<Payment | null> {
+    const db = (tx as Prisma.TransactionClient) ?? this.prisma;
+
+    // Optimistic guard: only a still-settleable row flips. count===0 means another
+    // webhook delivery already settled it, so the caller treats this as a no-op.
+    const { count } = await db.payment.updateMany({
+      where: { id: input.id, status: { in: [...SETTLEABLE_PAYMENT_STATUSES] } },
+      data: { status: input.status },
+    });
+
+    if (count === 0) {
+      return null;
+    }
+
+    const raw = await db.payment.findUnique({ where: { id: input.id } });
+    return raw ? this.toEntity(raw) : null;
+  }
+
+  async cancelStaleReservations(olderThan: Date): Promise<number> {
+    // Only abandoned reservations: still PENDING and never charged (null extTransactionId).
+    // PROCESSING is excluded on purpose - a charge there may have moved money.
+    const { count } = await this.prisma.payment.updateMany({
+      where: {
+        status: PaymentStatus.PENDING,
+        extTransactionId: null,
+        createdAt: { lt: olderThan },
+      },
+      data: { status: PaymentStatus.CANCELLED },
+    });
+    return count;
+  }
+
+  private toEntity(raw: PaymentModel): Payment {
+    return new Payment(
+      raw.id,
+      raw.orderId,
+      new Big(raw.amount.toString()),
+      raw.method,
+      raw.status,
+      raw.extTransactionId,
+      raw.createdAt,
+      raw.updatedAt,
+    );
+  }
+}

--- a/src/modules/payments/infrastructure/scheduling/stale-payment.sweeper.ts
+++ b/src/modules/payments/infrastructure/scheduling/stale-payment.sweeper.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common';
+import { ExpireStalePaymentsUseCase } from '../../application/use-cases/expire-stale-payments.use-case';
+
+/** How often the sweep runs. */
+const SWEEP_INTERVAL_MS = 5 * 60_000;
+/** Reservations older than this (still PENDING, never charged) are cancelled. */
+const RESERVATION_TTL_MS = 15 * 60_000;
+
+/**
+ * Dependency-free scheduler for the stale-reservation sweep (no @nestjs/schedule yet). The
+ * timer is unref'd so it never keeps the process - or a Jest worker - alive, and it is
+ * cleared on shutdown. Real cron/queue scheduling can replace this later without touching
+ * the use case.
+ */
+@Injectable()
+export class StalePaymentSweeper implements OnApplicationBootstrap, OnModuleDestroy {
+  private readonly logger = new Logger(StalePaymentSweeper.name);
+  private timer?: NodeJS.Timeout;
+
+  constructor(private readonly expireStale: ExpireStalePaymentsUseCase) {}
+
+  onApplicationBootstrap(): void {
+    this.timer = setInterval(() => void this.sweep(), SWEEP_INTERVAL_MS);
+    this.timer.unref();
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+  }
+
+  private async sweep(): Promise<void> {
+    try {
+      const cancelled = await this.expireStale.execute(RESERVATION_TTL_MS);
+      if (cancelled > 0) {
+        this.logger.log(`Cancelled ${cancelled} stale payment reservation(s).`);
+      }
+    } catch (err) {
+      this.logger.error(
+        'Stale payment sweep failed',
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+}

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -1,0 +1,42 @@
+import { Module } from '@nestjs/common';
+import { AuditModule } from '@modules/audit/audit.module';
+import { OrdersModule } from '@modules/orders/orders.module';
+import { TRANSACTION_RUNNER } from '@shared/transaction/transaction-runner.port';
+import { PrismaTransactionRunner } from '@shared/infrastructure/prisma/prisma-transaction-runner';
+import { PaymentsController } from './infrastructure/http/controllers/payments.controller';
+import { PaymentWebhookGuard } from './infrastructure/http/guards/payment-webhook.guard';
+import { PAYMENT_REPOSITORY } from './domain/repositories/payment.repository';
+import { PrismaPaymentRepository } from './infrastructure/persistence/prisma-payment.repository';
+import { PAYMENT_GATEWAY } from './application/ports/payment-gateway.port';
+import { MockPaymentGateway } from './infrastructure/gateway/mock-payment-gateway';
+import { CreatePaymentUseCase } from './application/use-cases/create-payment.use-case';
+import { ConfirmPaymentUseCase } from './application/use-cases/confirm-payment.use-case';
+import { FindPaymentByOrderUseCase } from './application/use-cases/find-payment-by-order.use-case';
+import { ExpireStalePaymentsUseCase } from './application/use-cases/expire-stale-payments.use-case';
+import { StalePaymentSweeper } from './infrastructure/scheduling/stale-payment.sweeper';
+
+@Module({
+  imports: [OrdersModule, AuditModule],
+  controllers: [PaymentsController],
+  providers: [
+    {
+      provide: PAYMENT_REPOSITORY,
+      useClass: PrismaPaymentRepository,
+    },
+    {
+      provide: PAYMENT_GATEWAY,
+      useClass: MockPaymentGateway,
+    },
+    {
+      provide: TRANSACTION_RUNNER,
+      useClass: PrismaTransactionRunner,
+    },
+    PaymentWebhookGuard,
+    CreatePaymentUseCase,
+    ConfirmPaymentUseCase,
+    FindPaymentByOrderUseCase,
+    ExpireStalePaymentsUseCase,
+    StalePaymentSweeper,
+  ],
+})
+export class PaymentsModule {}

--- a/src/shared/auth/current-user.decorator.ts
+++ b/src/shared/auth/current-user.decorator.ts
@@ -4,7 +4,7 @@ import { JwtPayload } from './jwt-payload.type';
 
 /**
  * Reads the authenticated principal that {@link AuthGuard} attaches to the
- * request after verifying the JWT. Throws if it is absent — that means the
+ * request after verifying the JWT. Throws if it is absent - that means the
  * route ran without the guard (e.g. it is @Public), which is a programming
  * error for any handler asking for the current user.
  */

--- a/src/shared/errors/domain/domain.error.ts
+++ b/src/shared/errors/domain/domain.error.ts
@@ -2,7 +2,7 @@ import { ErrorKind } from '../errors.type';
 
 /**
  * Base class for domain-rule violations (invariants broken in `domain/`). Carries a
- * transport-agnostic {@link ErrorKind} that the global filter maps to an HTTP status —
+ * transport-agnostic {@link ErrorKind} that the global filter maps to an HTTP status -
  * the domain never throws `HttpException`. `new.target.name` sets `name` to the actual
  * subclass (e.g. `InvalidOrderStatusTransitionError`), not `DomainError`.
  */

--- a/src/shared/pagination/cursor-pagination-meta.dto.ts
+++ b/src/shared/pagination/cursor-pagination-meta.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 /**
  * Schema-only DTO: never instantiated at runtime. It exists so Swagger can
  * describe the `meta` envelope returned alongside cursor-paginated lists
- * (OpenAPI has no generics — a concrete class is needed). Keep its shape in
+ * (OpenAPI has no generics - a concrete class is needed). Keep its shape in
  * sync with `CursorPaginationMeta` in `pagination.ts`.
  */
 export class CursorPaginationMetaDto {

--- a/src/shared/pagination/pagination.ts
+++ b/src/shared/pagination/pagination.ts
@@ -1,7 +1,7 @@
 /**
  * Repository-level cursor pagination input.
  * `take` is the page size; `cursor` (when provided) marks the last item
- * of the previous page — results begin AFTER it.
+ * of the previous page - results begin AFTER it.
  */
 export interface CursorPaginationParams {
   cursor?: string;

--- a/test/auth-audit.e2e-spec.ts
+++ b/test/auth-audit.e2e-spec.ts
@@ -64,7 +64,7 @@ describe('Auth + AuditLog (e2e)', () => {
     await app.close();
   });
 
-  describe('POST /api/auth/login — success', () => {
+  describe('POST /api/auth/login - success', () => {
     it('writes a LOGIN_SUCCESS audit entry without password/token/cpf in metadata', async () => {
       const response: { body: { access_token: string } } = await request(server)
         .post('/api/auth/login')
@@ -87,7 +87,7 @@ describe('Auth + AuditLog (e2e)', () => {
     });
   });
 
-  describe('POST /api/auth/login — failure (wrong password)', () => {
+  describe('POST /api/auth/login - failure (wrong password)', () => {
     it('writes a LOGIN_FAILED audit entry with the matched userId', async () => {
       await request(server)
         .post('/api/auth/login')
@@ -103,7 +103,7 @@ describe('Auth + AuditLog (e2e)', () => {
     });
   });
 
-  describe('POST /api/auth/login — failure (unknown user)', () => {
+  describe('POST /api/auth/login - failure (unknown user)', () => {
     it('writes a LOGIN_FAILED audit entry with null userId', async () => {
       const ghostUsername = `ghost-${randomUUID()}`;
 

--- a/test/orders.e2e-spec.ts
+++ b/test/orders.e2e-spec.ts
@@ -427,7 +427,7 @@ describe('Orders (e2e)', () => {
 
       // Two staff fire the same PENDING -> CONFIRMED transition at once. The optimistic
       // lock must let exactly one win; the other is rejected with 409 (lost the race) or
-      // 422 (it serialized after and re-read CONFIRMED) — never a second silent apply.
+      // 422 (it serialized after and re-read CONFIRMED) - never a second silent apply.
       const patch = (): request.Test =>
         request(server)
           .patch(`/api/orders/${id}/status`)

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -1,0 +1,370 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import type { Server } from 'http';
+import request from 'supertest';
+import { randomUUID } from 'crypto';
+
+// The webhook guard reads this secret on boot; set it before AppModule loads.
+// dotenv does not override an already-set process.env var, so this wins over .env.
+const WEBHOOK_SECRET = `e2e-webhook-${randomUUID()}`;
+process.env.PAYMENT_WEBHOOK_SECRET = WEBHOOK_SECRET;
+
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '@shared/infrastructure/prisma/prisma.service';
+import { Argon2PasswordHasher } from '@modules/identity/infrastructure/security/argon2-password-hasher';
+import { buildWebhookSignature } from '@modules/payments/infrastructure/http/guards/payment-webhook.guard';
+
+interface PaymentBody {
+  id: string;
+  orderId: string;
+  amount: string;
+  status: string;
+  method: string;
+  extTransactionId: string | null;
+}
+
+interface OrderBody {
+  id: string;
+  orderStatus: string;
+  totalAmount: string;
+}
+
+describe('Payments - critical flow A (e2e)', () => {
+  let app: INestApplication;
+  let server: Server;
+  let prisma: PrismaService;
+
+  const password = 'customer-pass';
+  const username = `e2e-pay-customer-${randomUUID()}`;
+  let unitId: string;
+  let categoryId: string;
+  let productId: string;
+  let customerId: string;
+  let token: string;
+  let otherCustomerId: string;
+  let otherToken: string;
+
+  const createOrder = async (unitPrice: string, quantity: number): Promise<OrderBody> => {
+    const res = await request(server)
+      .post('/api/orders')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        businessUnitId: unitId,
+        orderChannel: 'APP',
+        orderItems: [{ productId, quantity, unitPrice }],
+      })
+      .expect(201);
+    return res.body as OrderBody;
+  };
+
+  // Posts a gateway webhook signed with the same HMAC scheme the guard verifies.
+  const postWebhook = (payload: { extTransactionId: string; status: string; amount: string }) => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = buildWebhookSignature(WEBHOOK_SECRET, {
+      timestamp,
+      extTransactionId: payload.extTransactionId,
+      status: payload.status,
+      amount: payload.amount,
+    });
+    return request(server)
+      .post('/api/payments/webhook')
+      .set('x-webhook-signature', signature)
+      .set('x-webhook-timestamp', timestamp)
+      .send(payload);
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: false },
+      }),
+    );
+    await app.init();
+
+    server = app.getHttpServer() as Server;
+    prisma = moduleFixture.get(PrismaService);
+
+    const tag = randomUUID().slice(0, 8);
+    const unit = await prisma.businessUnit.create({
+      data: {
+        name: `E2E Pay Unit ${tag}`,
+        cnpj: `e2e-pay-cnpj-${tag}`,
+        address: 'rua e2e',
+        city: 'Recife',
+        phone: `e2e-pay-phone-${tag}`,
+      },
+    });
+    unitId = unit.id;
+
+    const category = await prisma.category.create({
+      data: { name: `E2E Pay Cat ${tag}`, description: 'e2e' },
+    });
+    categoryId = category.id;
+
+    const product = await prisma.product.create({
+      data: {
+        name: `E2E Pay Product ${tag}`,
+        description: 'e2e',
+        basePrice: '12.50',
+        imageUrl: 'https://example.com/e2e.jpg',
+        categoryId: category.id,
+      },
+    });
+    productId = product.id;
+
+    await prisma.businessUnitMenuItem.create({
+      data: {
+        businessUnitId: unit.id,
+        productId: product.id,
+        customPrice: '12.50',
+        isAvailable: true,
+      },
+    });
+
+    const hasher = new Argon2PasswordHasher();
+    const passwordHash = await hasher.hash(password);
+    const user = await prisma.user.create({
+      data: {
+        name: 'E2E Pay Customer',
+        username,
+        passwordHash,
+        role: 'CUSTOMER',
+        businessUnitId: unit.id,
+      },
+    });
+    customerId = user.id;
+
+    const login: { body: { access_token: string } } = await request(server)
+      .post('/api/auth/login')
+      .send({ username, password })
+      .expect(200);
+    token = login.body.access_token;
+
+    // A second customer, used to prove a customer cannot pay someone else's order.
+    const otherUsername = `e2e-pay-other-${tag}`;
+    const other = await prisma.user.create({
+      data: {
+        name: 'E2E Pay Other',
+        username: otherUsername,
+        passwordHash,
+        role: 'CUSTOMER',
+        businessUnitId: unit.id,
+      },
+    });
+    otherCustomerId = other.id;
+    const otherLogin: { body: { access_token: string } } = await request(server)
+      .post('/api/auth/login')
+      .send({ username: otherUsername, password })
+      .expect(200);
+    otherToken = otherLogin.body.access_token;
+  });
+
+  afterAll(async () => {
+    await prisma.payment.deleteMany({ where: { order: { businessUnitId: unitId } } });
+    await prisma.orderItem.deleteMany({ where: { order: { businessUnitId: unitId } } });
+    await prisma.order.deleteMany({ where: { businessUnitId: unitId } });
+    await prisma.auditLog.deleteMany({ where: { userId: { in: [customerId, otherCustomerId] } } });
+    await prisma.businessUnitMenuItem.deleteMany({ where: { businessUnitId: unitId } });
+    await prisma.product.deleteMany({ where: { categoryId } });
+    await prisma.category.deleteMany({ where: { id: categoryId } });
+    await prisma.user.deleteMany({ where: { id: { in: [customerId, otherCustomerId] } } });
+    await prisma.businessUnit.deleteMany({ where: { id: unitId } });
+    await app.close();
+  });
+
+  it('runs login, order, payment, webhook then order CONFIRMED with the expected audit trail', async () => {
+    const order = await createOrder('12.50', 2);
+    expect(order.orderStatus).toBe('PENDING');
+    expect(order.totalAmount).toBe('25.00');
+
+    // Webhook is the source of truth, so the payment starts as PROCESSING.
+    const createRes = await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(201);
+    const payment = createRes.body as PaymentBody;
+    expect(payment.status).toBe('PROCESSING');
+    expect(payment.amount).toBe('25.00');
+    expect(payment.extTransactionId).toEqual(expect.any(String));
+
+    const webhookRes = await postWebhook({
+      extTransactionId: payment.extTransactionId as string,
+      status: 'APPROVED',
+      amount: payment.amount,
+    }).expect(200);
+    expect(webhookRes.body).toEqual({ received: true });
+
+    // Order advanced to CONFIRMED through the payment hook.
+    const orderRes = await request(server)
+      .get(`/api/orders/${order.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect((orderRes.body as OrderBody).orderStatus).toBe('CONFIRMED');
+
+    // GET /orders/:orderId/payment returns the settled payment to the owner.
+    const findRes = await request(server)
+      .get(`/api/orders/${order.id}/payment`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect((findRes.body as PaymentBody).status).toBe('APPROVED');
+
+    const actions = (await prisma.auditLog.findMany({ where: { userId: customerId } })).map(
+      (r) => r.action,
+    );
+    expect(actions).toEqual(expect.arrayContaining(['ORDER_CREATED', 'PAYMENT_CREATED']));
+    // The payment-driven confirm runs inside the payment transaction, so it does NOT emit
+    // a separate ORDER_STATUS_CHANGED (that would risk auditing a change the tx may roll
+    // back). The confirmation is traced by PAYMENT_APPROVED instead.
+    const orderAudit = await prisma.auditLog.findMany({
+      where: { entity: 'Order', entityId: order.id },
+    });
+    expect(orderAudit.some((r) => r.action === 'ORDER_STATUS_CHANGED')).toBe(false);
+    const paymentAudit = await prisma.auditLog.findMany({
+      where: { entity: 'Payment', entityId: payment.id },
+    });
+    expect(paymentAudit.some((r) => r.action === 'PAYMENT_APPROVED')).toBe(true);
+  });
+
+  it('rejects a webhook with no signature (401)', async () => {
+    await request(server)
+      .post('/api/payments/webhook')
+      .send({ extTransactionId: 'whatever', status: 'APPROVED', amount: '25.00' })
+      .expect(401);
+  });
+
+  it('acks an unknown transaction with 200 instead of a 404 retry storm', async () => {
+    const res = await postWebhook({
+      extTransactionId: `mock_${randomUUID()}`,
+      status: 'APPROVED',
+      amount: '25.00',
+    }).expect(200);
+    expect(res.body).toEqual({ received: true });
+  });
+
+  it('rejects a payment for a non-existent order (404)', async () => {
+    await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: randomUUID(), method: 'PIX' })
+      .expect(404);
+  });
+
+  it("hides another customer's order behind a 404 when they try to pay it", async () => {
+    const order = await createOrder('12.50', 1); // owned by `customerId`
+
+    await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(404);
+
+    // Owner's order was never locked, so they can still pay it.
+    await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(201);
+  });
+
+  it('settles the payment without rolling back when the order already moved on (cancelled)', async () => {
+    const order = await createOrder('12.50', 1);
+
+    const createRes = await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(201);
+    const payment = createRes.body as PaymentBody;
+
+    // The order moves on (e.g. customer cancels) while the charge is in flight.
+    await prisma.order.update({ where: { id: order.id }, data: { orderStatus: 'CANCELLED' } });
+
+    // The webhook must still settle the payment (money is the source of truth), not 422/500.
+    const webhookRes = await postWebhook({
+      extTransactionId: payment.extTransactionId as string,
+      status: 'APPROVED',
+      amount: payment.amount,
+    }).expect(200);
+    expect(webhookRes.body).toEqual({ received: true });
+
+    // Order stays CANCELLED and the mismatch is flagged for reconciliation.
+    const dbOrder = await prisma.order.findUnique({ where: { id: order.id } });
+    expect(dbOrder?.orderStatus).toBe('CANCELLED');
+    const reconcile = await prisma.auditLog.findMany({
+      where: { entity: 'Payment', entityId: payment.id, action: 'PAYMENT_RECONCILE_REQUIRED' },
+    });
+    expect(reconcile.length).toBeGreaterThan(0);
+  });
+
+  it('rejects paying the same order twice (422)', async () => {
+    const order = await createOrder('12.50', 1);
+
+    await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(201);
+
+    await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(422);
+  });
+
+  it('allows a new payment attempt after a refusal, then confirms the order', async () => {
+    const order = await createOrder('12.50', 1);
+
+    // First attempt is REFUSED, so the order stays PENDING.
+    const firstRes = await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(201);
+    const first = firstRes.body as PaymentBody;
+
+    await postWebhook({
+      extTransactionId: first.extTransactionId as string,
+      status: 'REFUSED',
+      amount: first.amount,
+    }).expect(200);
+
+    const afterRefusal = await request(server)
+      .get(`/api/orders/${order.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect((afterRefusal.body as OrderBody).orderStatus).toBe('PENDING');
+
+    // A refused attempt does not occupy the slot: a fresh attempt is allowed.
+    const retryRes = await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: order.id, method: 'PIX' })
+      .expect(201);
+    const retry = retryRes.body as PaymentBody;
+    expect(retry.extTransactionId).not.toBe(first.extTransactionId);
+
+    await postWebhook({
+      extTransactionId: retry.extTransactionId as string,
+      status: 'APPROVED',
+      amount: retry.amount,
+    }).expect(200);
+
+    const confirmed = await request(server)
+      .get(`/api/orders/${order.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect((confirmed.body as OrderBody).orderStatus).toBe('CONFIRMED');
+  });
+});

--- a/test/validation-pipe.e2e-spec.ts
+++ b/test/validation-pipe.e2e-spec.ts
@@ -39,10 +39,9 @@ describe('ValidationPipe (e2e)', () => {
     await app.close();
   });
 
-  describe('forbidNonWhitelisted — unknown properties rejected', () => {
+  describe('forbidNonWhitelisted - unknown properties rejected', () => {
     it('rejects a login body carrying an extra field (400)', async () => {
-      // username/password are valid on their own, so 400 is caused
-      // *only* by the unknown `role` field -> proves forbidNonWhitelisted.
+      // username/password are valid, so the 400 comes only from the unknown `role` field.
       await request(server)
         .post('/api/auth/login')
         .send({ username: 'someone', password: 'supersecret', role: 'ADMIN' })
@@ -54,16 +53,14 @@ describe('ValidationPipe (e2e)', () => {
     });
   });
 
-  describe('type validation — wrong types rejected', () => {
-    // DoD: "string in a number field -> 400". @Type(() => Number) coerces
-    // "abc" -> NaN, then @IsInt fails.
+  describe('type validation - wrong types rejected', () => {
+    // @Type(() => Number) turns "abc" into NaN, then @IsInt fails.
     it('rejects a non-numeric "limit" query param (400)', async () => {
       await request(server).get('/api/products?limit=abc').expect(400);
     });
 
-    // With enableImplicitConversion OFF and no @Type on username, 12345
-    // stays a number, so @IsString rejects it -> 400. Under implicit
-    // conversion this would be stringified first and slip through.
+    // With implicit conversion off and no @Type on username, 12345 stays a
+    // number, so @IsString rejects it.
     it('rejects a non-string username in the login body (400)', async () => {
       await request(server)
         .post('/api/auth/login')
@@ -82,20 +79,17 @@ describe('ValidationPipe (e2e)', () => {
     });
 
     it('coerces a valid numeric "limit" via explicit @Type (200)', async () => {
-      // Proves @Type(() => Number) still converts the query string with
-      // implicit conversion OFF — @Type is now load-bearing, not redundant.
+      // @Type(() => Number) still converts the query string with implicit conversion off.
       await request(server).get('/api/products?limit=5').expect(200);
     });
 
     it('clamps an out-of-range "limit" instead of rejecting it (200)', async () => {
-      // By design: limit bounds are clamped by sanitizeLimit, not
-      // rejected by @Max. ?limit=99999 -> clamped to MAX_LIMIT, 200.
+      // limit is clamped by sanitizeLimit, not rejected by @Max, so 99999 becomes MAX_LIMIT.
       await request(server).get('/api/products?limit=99999').expect(200);
     });
 
     it('lets a well-formed login through to the use-case (not 400)', async () => {
-      // Unknown user -> the use-case rejects it (401), but the request
-      // reached the use-case at all, proving the pipe let it through.
+      // Unknown user gets a 401 from the use-case, which proves the pipe let it through.
       const response = await request(server)
         .post('/api/auth/login')
         .send({ username: 'nonexistent-user', password: 'supersecret' });


### PR DESCRIPTION
A Payment is now an attempt (many per order, at most one live), guarded by a partial unique index. The charge flow reserves before charging; the gateway webhook settles the outcome and confirms the order in one transaction. Failure handling distinguishes definite (slot freed) from ambiguous (slot held for reconciliation) so a retry can never double-charge.

- domain: Payment entity, PaymentStatus/PaymentMethod VOs, repository port
- application: create/confirm/find/expire use cases, gateway port, errors
- infra: Prisma repo, mock gateway, HMAC-signed webhook guard (timestamp anti-replay + timing-safe compare), stale-reservation sweeper, controller + DTOs
- orders: published OrderForPayment port so payments never imports the Order entity; order total is now persisted-authoritative with a derived discount band; updateStatus threads an optional tx for atomic settle+confirm
- audit: PAYMENT_CREATED/APPROVED/REFUSED/RECONCILE_REQUIRED actions, best-effort contract on the logger port
- migration: drop one-payment-per-order, add partial unique index on live attempts
- docs: README + PAYMENT_WEBHOOK_SECRET in .env.example
- chore: normalize comment punctuation to plain ASCII across misc files

Closes #21 
Closes #22
Closes #23
Closes #24 
Closes #25 
Closes #26 
Closes #27