### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raizes-do-nordeste",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raizes-do-nordeste",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raizes-do-nordeste",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Multi-unit restaurant management API for Raízes do Nordeste",
   "author": "Marcos Paulo Freire Almeida",
   "private": true,


### PR DESCRIPTION
Version bump 0.0.1 to 0.1.0 (npm version minor).

First tagged release. Bundles the inventory and loyalty bounded contexts and the post-review hardening: required tx on the atomic write seams, idempotent EARN via a unique index, and loyalty read failures surfaced as 503.

The tag v0.1.0 already points at this commit. Merge with a merge commit (not squash) so the SHA is preserved and the tag stays valid.