### PR TITLE
docs: document shipped contexts and add smoke-test collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ customer loyalty program - across multiple business units (franchises).
 > is the product catalog (public browsing + role-gated creation), identity
 > (JWT login + argon2 hashing + global role guard), a cross-cutting audit
 > log wired into the login flow, **orders** (channel-aware creation, reads,
-> status state machine), and **payments** (gateway charge + webhook
-> confirmation that advances the order). Inventory, promotions and loyalty
-> are planned (see [Roadmap](#roadmap)).
+> status state machine), **payments** (gateway charge + HMAC-signed webhook
+> confirmation that advances the order, plus a stale-payment sweeper),
+> **inventory** (stock deducted atomically on order creation, manual
+> adjustments, low-stock alerts) and **loyalty** (auto-enrolment on the first
+> order, consent-gated points credited on approved payments). Promotions are
+> the only context still pending (see [Roadmap](#roadmap)).
 
 ---
 
@@ -267,29 +270,43 @@ src/
     │   ├── domain/               ← User entity, repo + hasher/signer ports, UserRole
     │   ├── application/          ← SignInUseCase + app-layer errors
     │   └── infrastructure/       ← Argon2 hasher, JWT signer, auth controller/DTO
-    ├── orders/                   ← Channel-aware order creation
+    ├── orders/                   ← Channel-aware creation, reads, status state machine
     │   ├── orders.module.ts
-    │   ├── domain/               ← Order/OrderItem entities, OrderChannel/Status VOs (channel policies), OrderRepository, NOT_FOUND errors
-    │   ├── application/          ← Use cases + OrderForPayment port (published to payments) + errors
+    │   ├── domain/               ← Order/OrderItem entities, OrderChannel/Status VOs (channel policies + transitions), OrderRepository, errors
+    │   ├── application/          ← Use cases (create/find/list/update-status), OrderForPayment + OrderProductLookup ports, errors
     │   └── infrastructure/       ← PrismaOrderRepository, OrdersController, request/response DTOs
-    └── payments/                 ← Gateway charge + webhook confirmation
-        ├── payments.module.ts
-        ├── domain/               ← Payment entity, PaymentStatus/PaymentMethod VOs, PaymentRepository
-        ├── application/          ← CreatePayment/ConfirmPayment/FindPaymentByOrder, PaymentGateway port, errors
-        └── infrastructure/       ← MockPaymentGateway, PrismaPaymentRepository, PaymentsController, webhook guard, DTOs
+    ├── payments/                 ← Gateway charge + HMAC-signed webhook confirmation
+    │   ├── payments.module.ts
+    │   ├── domain/               ← Payment entity, PaymentStatus/PaymentMethod VOs, PaymentRepository
+    │   ├── application/          ← CreatePayment/ConfirmPayment/FindPaymentByOrder/ExpireStalePayments, PaymentGateway port, errors
+    │   └── infrastructure/       ← MockPaymentGateway, PrismaPaymentRepository, PaymentsController, webhook signature guard, DTOs
+    ├── inventory/                ← Stock balances + transaction ledger
+    │   ├── inventory.module.ts
+    │   ├── domain/               ← Inventory entity, InventoryTransactionType VO, InventoryRepository, errors
+    │   ├── application/          ← GetInventory/AdjustInventory/DeductStockForOrder, StockDeduction port (consumed by orders), errors
+    │   └── infrastructure/       ← PrismaInventoryRepository, InventoryController, DTOs
+    └── loyalty/                  ← Customer points program (LGPD consent-gated)
+        ├── loyalty.module.ts
+        ├── domain/               ← LoyaltyAccount/LoyaltyTransaction entities, VOs, repository
+        ├── application/          ← EnrollCustomer/EarnPoints/GetMyLoyaltyAccount, LoyaltyEnrollment + LoyaltyEarning ports, errors
+        └── infrastructure/       ← PrismaLoyaltyRepository, LoyaltyController, DTOs
 prisma/
 ├── schema.prisma                 ← Single source of truth for the database
 ├── seed.ts                       ← Idempotent seed for local dev
 └── migrations/                   ← Versioned migration history
+docs/
+└── TESTS.md                      ← Smoke-test scenarios (positive + negative)
 test/
 ├── app.e2e-spec.ts               ← Product HTTP e2e
 ├── auth-audit.e2e-spec.ts        ← Login + audit_logs persistence e2e
 ├── validation-pipe.e2e-spec.ts   ← Global ValidationPipe e2e
-└── global-error-filter.e2e-spec.ts ← Error envelope e2e (full pipeline)
+├── global-error-filter.e2e-spec.ts ← Error envelope e2e (full pipeline)
+├── orders.e2e-spec.ts            ← Orders + inventory + loyalty enrolment e2e
+└── payments.e2e-spec.ts          ← Critical flow A (order → pay → webhook → confirm) e2e
 ```
 
-> Remaining contexts (`inventory`, `promotions`, `loyalty`) will follow the
-> same internal shape under `src/modules/`.
+> `promotions` is the only remaining context; it will follow the same
+> internal shape under `src/modules/`.
 
 ---
 
@@ -326,6 +343,7 @@ NODE_ENV=development
 PORT=3000
 
 JWT_SECRET_KEY=replace-with-a-strong-random-secret
+PAYMENT_WEBHOOK_SECRET=replace-with-a-strong-random-secret
 ```
 
 > `DATABASE_URL` uses `localhost` for local development. The full-stack
@@ -339,6 +357,11 @@ JWT_SECRET_KEY=replace-with-a-strong-random-secret
 > ```bash
 > node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 > ```
+>
+> `PAYMENT_WEBHOOK_SECRET` signs the payment webhook (HMAC-SHA256). The guard
+> fails closed if it is unset, so `POST /api/payments/webhook` returns `401`
+> until it is configured. Any caller posting a webhook (a test, a Postman
+> collection, or a real gateway adapter) must sign with the same value.
 
 ### 3. Install dependencies and generate the Prisma client
 
@@ -423,6 +446,8 @@ npm run devs
 | `DATABASE_URL`      | Full connection string consumed by Prisma | `postgresql://...`           |
 | `NODE_ENV`          | Runtime environment                       | `development` / `production` |
 | `PORT`              | HTTP server port                          | `3000`                       |
+| `JWT_SECRET_KEY`    | Signing secret for access tokens. **Required** - the app exits on boot if missing (`getOrThrow`). | `a-strong-random-secret` |
+| `PAYMENT_WEBHOOK_SECRET` | HMAC secret the payment webhook is signed with. If unset, the webhook guard **fails closed** (every callback returns `401`). | `dev-webhook-secret` |
 
 ---
 
@@ -441,11 +466,10 @@ npm run devs
 | Promotions        | `promotions`, `order_promotions`                                       |
 | Loyalty           | `loyalty_accounts`, `loyalty_transactions`                             |
 
-> Of the domains above, **Identity, Business Units, Audit and Orders**
-> (creation only) have application code shipped. The remaining tables
-> (Inventory, Payments, Promotions, Loyalty) exist in the schema as
-> forward-looking infrastructure - there are no use cases, controllers or
-> repositories for them yet.
+> Of the domains above, **Identity, Business Units, Audit, Orders, Payments,
+> Inventory and Loyalty** have application code shipped. Only **Promotions**
+> (`promotions`, `order_promotions`) exists in the schema as forward-looking
+> infrastructure - it has no use cases, controllers or repositories yet.
 
 ### Design Decisions
 
@@ -491,13 +515,14 @@ returned by `POST /api/auth/login` directly into the "Authorize" dialog.
 ### Authentication
 
 A global `AuthGuard` protects every route by default; routes opt out with
-`@Public()`. The read endpoints shipped so far are public; **writes are
-protected** - `POST /api/products` requires a `Bearer` JWT in the
-`Authorization` header and the `ADMIN` or `MANAGER` role (via `@Roles()`).
-`POST /api/orders` also requires a Bearer JWT, but the required role is not
-fixed on the route: it is enforced per request by the `orderChannel` policy
-(see [Orders](#orders)). A protected route returns `401` when the JWT is
-missing or invalid and `403` when the role is insufficient.
+`@Public()`. Only the **product reads** and the **payment webhook** are public;
+everything else needs a `Bearer` JWT in the `Authorization` header. Some routes
+additionally require a role via `@Roles()` - `POST /api/products` needs
+`ADMIN`/`MANAGER`, inventory needs `MANAGER`/`ADMIN`, order listing/status needs
+staff, and `loyalty/me` needs `CUSTOMER`. `POST /api/orders` needs a JWT but no
+fixed role: the requirement is enforced per request by the `orderChannel` policy
+(see [Orders](#orders)). A protected route returns `401` when the JWT is missing
+or invalid and `403` when the role is insufficient.
 
 | Method | Path              | Auth   | Description                                 |
 | ------ | ----------------- | ------ | ------------------------------------------- |
@@ -567,9 +592,12 @@ digits, matching the `Decimal(10, 2)` column); `imageUrl` must be a valid URL;
 
 ### Orders
 
-| Method | Path          | Auth   | Description                                                                                            |
-| ------ | ------------- | ------ | ------------------------------------------------------------------------------------------------------ |
-| `POST` | `/api/orders` | Bearer | Create an order. Behavior is driven by the `orderChannel` policy (customer source + role requirement). |
+| Method  | Path                      | Auth        | Description                                                                                            |
+| ------- | ------------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `POST`  | `/api/orders`             | Bearer      | Create an order. Behavior is driven by the `orderChannel` policy (customer source + role requirement). |
+| `GET`   | `/api/orders`             | Staff       | List orders (cursor-paginated) with optional `businessUnitId`/`orderChannel`/`orderStatus` filters. `CUSTOMER` is rejected with `403`. |
+| `GET`   | `/api/orders/:id`         | Bearer      | Get one order. A `CUSTOMER` only sees their own; otherwise `404`.                                      |
+| `PATCH` | `/api/orders/:id/status`  | Staff       | Advance an order's status. The state machine rejects invalid transitions with `422`; a concurrent change loses the optimistic lock with `409`. |
 
 #### Channel policies
 
@@ -604,12 +632,12 @@ write reaches the database. The `OrderPricing` port returns `{ price, isActive }
 per product; the Prisma implementation batches the product + menu-item
 fetches in parallel.
 
-`pointsEarned` is **not** accepted from the client either. It is reserved for
-the future loyalty module: once `LoyaltyAccount` is built, an order whose
-customer has an account with `consentGiven=true` will earn `floor(totalAmount)`
-points (1 point per real). Until then every order persists `pointsEarned = 0`
-(the schema default). A `TODO(loyalty)` marker lives in
-`CreateOrderUseCase.execute` at the point where this computation will be added.
+`pointsEarned` is **not** accepted from the client either, and stays `0` on the
+order at creation time. Loyalty points are credited later by the loyalty module,
+when the payment is **approved**: `floor(paidAmount / 10)` points (1 per R$10),
+gated by the customer's `LoyaltyAccount` consent and recorded as a
+`LoyaltyTransaction` (the source of truth). The account is created automatically
+on the customer's first order. See [Loyalty](#loyalty).
 
 ```json
 {
@@ -662,12 +690,27 @@ translates Prisma's `P2003` into a typed domain error and inspects
 (`customer`, `business unit`, `product`, `attendant`) instead of grouping all
 foreign-key failures under one generic label.
 
+#### Order status transitions
+
+`PATCH /api/orders/:id/status` enforces a forward-only state machine
+(`OrderStatus` VO). Allowed moves:
+
+- `PENDING` -> `CONFIRMED` | `CANCELLED`
+- `CONFIRMED` -> `PREPARING` | `CANCELLED`
+- `PREPARING` -> `READY` | `CANCELLED`
+- `READY` -> `DELIVERED`
+- `DELIVERED` and `CANCELLED` are terminal
+
+An invalid transition returns `422`; an unknown order returns `404`; a
+concurrent transition that loses the optimistic lock returns `409`. An
+approved payment advances `PENDING -> CONFIRMED` automatically (see below).
+
 ### Payments
 
 | Method | Path                           | Auth           | Description                                                    |
 | ------ | ------------------------------ | -------------- | -------------------------------------------------------------- |
 | `POST` | `/api/payments`                | Bearer         | Create a payment for an order and charge the gateway.          |
-| `POST` | `/api/payments/webhook`        | Webhook secret | Gateway callback: settle a payment and advance its order.      |
+| `POST` | `/api/payments/webhook`        | HMAC signature | Gateway callback: settle a payment and advance its order.      |
 | `GET`  | `/api/orders/:orderId/payment` | Bearer         | Get the payment of an order. Customers may only see their own. |
 
 #### The webhook is the source of truth
@@ -701,12 +744,22 @@ the concurrent double-payment race).
 
 #### Request body - `PaymentWebhookDto` (`POST /api/payments/webhook`)
 
-The request must carry the shared secret in the **`x-webhook-secret`** header
-(stand-in for gateway signature verification); a missing/invalid secret returns
-`401`. `status` is the settled outcome the gateway reports.
+The callback is verified by an HMAC-SHA256 signature (not a static shared
+secret), so a captured request cannot be replayed and the body cannot be
+tampered. The caller sends two headers:
+
+- **`x-webhook-timestamp`** - Unix seconds; rejected if more than 300s from now
+  (anti-replay window).
+- **`x-webhook-signature`** - hex HMAC-SHA256, keyed with `PAYMENT_WEBHOOK_SECRET`,
+  over the canonical string `timestamp.extTransactionId.status.amount`.
+
+A missing/invalid signature, a stale timestamp, or an unset server secret all
+return `401`. `status` is the settled outcome (`APPROVED` / `REFUSED`) and
+`amount` must match what was charged. The signing helper `buildWebhookSignature`
+is exported from the webhook guard for tests and future PSP adapters.
 
 ```json
-{ "extTransactionId": "mock_4f1c...", "status": "APPROVED" }
+{ "extTransactionId": "mock_4f1c...", "status": "APPROVED", "amount": "25.00" }
 ```
 
 #### Response - `PaymentResponseDto`
@@ -738,6 +791,71 @@ rounding on the client.
 > acceptance. `PENDING -> CONFIRMED` was already a valid transition, so the state
 > machine was not changed.
 
+### Inventory
+
+| Method | Path                                | Auth            | Description                                              |
+| ------ | ----------------------------------- | --------------- | ------------------------------------------------------- |
+| `GET`  | `/api/inventory/:businessUnitId`    | MANAGER / ADMIN | List stock balances for a business unit.                |
+| `POST` | `/api/inventory/:businessUnitId/adjust` | MANAGER / ADMIN | Apply a manual `IN`/`OUT` stock movement.           |
+
+Stock is a management concern: `ATTENDANT`, `KITCHEN` and `CUSTOMER` are
+rejected with `403`. Every balance change is recorded as an
+`InventoryTransaction` (the balance is never mutated blind).
+
+#### Stock is deducted when an order is created
+
+`POST /api/orders` deducts stock for each item **in the same transaction** as
+the order insert. An item without an inventory row at the unit, or without
+enough on hand, fails the whole order with `422` and rolls back every deduction
+already applied (no partial outflow). When a deduction leaves the balance at or
+below `minQuantity`, a `STOCK_ALERT` is written to the audit log.
+
+#### Request body - `AdjustInventoryDto` (`POST /api/inventory/:businessUnitId/adjust`)
+
+`type` is `IN` (restock) or `OUT` (manual removal). An `IN` for a product with
+no inventory row at the unit returns `404`; an `OUT` that would drive the
+balance below zero returns `422`.
+
+```json
+{ "productId": "cebe6acf-...", "type": "IN", "quantity": 10, "reason": "Weekly restock delivery." }
+```
+
+#### Response - `InventoryResponseDto`
+
+```json
+{
+  "id": "a1b2...",
+  "businessUnitId": "e36e29da-...",
+  "productId": "cebe6acf-...",
+  "quantity": 110,
+  "minQuantity": 5,
+  "updatedAt": "2026-06-14T12:00:00.000Z"
+}
+```
+
+### Loyalty
+
+| Method | Path              | Auth     | Description                                          |
+| ------ | ----------------- | -------- | --------------------------------------------------- |
+| `GET`  | `/api/loyalty/me` | CUSTOMER | Get the authenticated customer's loyalty account.   |
+
+A customer's `LoyaltyAccount` is created automatically on their **first order**
+(with `consentGiven = false`). `GET /api/loyalty/me` returns `404` for a
+customer who has never ordered, and `403` for staff. Points are credited only
+when a payment is **approved**, only if the account has `consentGiven = true`
+(LGPD gate): `floor(paidAmount / 10)` points (1 point per R$10), recorded as a
+`LoyaltyTransaction` of type `EARN`. Redemption is not implemented yet.
+
+#### Response - `LoyaltyAccountResponseDto`
+
+```json
+{
+  "customerId": "f3b7...",
+  "totalPoints": 12,
+  "consentGiven": true
+}
+```
+
 ### Error responses
 
 Every error passes through the global exception filter and is returned with a
@@ -757,7 +875,7 @@ are logged server-side but never sent to the client:
 | Status | When                                                                                                                  |
 | ------ | --------------------------------------------------------------------------------------------------------------------- |
 | `400`  | Request body fails validation (`class-validator` + `ValidationPipe`)                                                  |
-| `401`  | Invalid login credentials, missing/invalid JWT, or a webhook with a missing/invalid secret                            |
+| `401`  | Invalid login credentials, missing/invalid JWT, or a webhook with a missing/invalid/stale signature                   |
 | `403`  | Authenticated but the role is not allowed (e.g. a `CUSTOMER` creating a `COUNTER` order)                              |
 | `404`  | Requested product/order/payment does not exist, or an order references a missing reference                            |
 | `409`  | A product with the same name already exists (`ProductAlreadyExistsError`)                                             |
@@ -794,19 +912,29 @@ npm run test:e2e
 ### Testing strategy
 
 - **Unit tests** substitute the repository interfaces (`ProductRepository`,
-  `UserRepository`, `OrderRepository`) with test doubles, so use cases and the
-  `AuthGuard` are validated without any database. Entities, value objects,
-  DTOs and the global exception filter are tested in isolation.
-- **e2e tests** boot the full Nest application against the development
-  database and exercise the HTTP surface - products
-  (`app.e2e-spec.ts`), login + audit-log persistence
-  (`auth-audit.e2e-spec.ts`), global validation rejection
-  (`validation-pipe.e2e-spec.ts`), and the global error envelope via a
-  throwing repository (`global-error-filter.e2e-spec.ts`).
-- Each test asserts both **success paths** and **failure paths** - including
-  `ProductNotFoundError` propagation, domain errors surfacing from the create
-  use case (`ProductAlreadyExistsError`), and `ProductsFetchError` wrapping
-  with `Error.cause`.
+  `UserRepository`, `OrderRepository`, `PaymentRepository`, `InventoryRepository`,
+  `LoyaltyRepository`) with test doubles, so use cases and the `AuthGuard` are
+  validated without any database. Entities, value objects, DTOs and the global
+  exception filter are tested in isolation.
+- **e2e tests** boot the full Nest application against the development database
+  and exercise the HTTP surface - products (`app.e2e-spec.ts`), login +
+  audit-log persistence (`auth-audit.e2e-spec.ts`), global validation rejection
+  (`validation-pipe.e2e-spec.ts`), the global error envelope via a throwing
+  repository (`global-error-filter.e2e-spec.ts`), orders + stock deduction +
+  loyalty enrolment (`orders.e2e-spec.ts`), and critical flow A - order, pay,
+  webhook, confirm - with the points and reconciliation paths
+  (`payments.e2e-spec.ts`).
+- Each test asserts both **success paths** and **failure paths**.
+
+### Manual / smoke tests
+
+[`docs/TESTS.md`](docs/TESTS.md) documents the smoke-test scenarios (6 positive,
+4 negative) covering login, order creation, payment + webhook, status
+transitions, the menu listing and stock deduction. Each scenario maps to a
+request in the Postman collection; run it with the Postman Runner or
+`newman run <collection>.json -e <env>.json` - the app must be up, the seed
+loaded, and `PAYMENT_WEBHOOK_SECRET` set to the same value the collection signs
+with.
 
 ---
 
@@ -827,30 +955,31 @@ npm run test:e2e
 
 ## Roadmap
 
-The product catalog, identity and audit modules are shipped. Upcoming
-modules - already designed in the database schema - are:
+The catalog, identity, audit, orders, payments, inventory and loyalty modules
+are shipped. Remaining work:
 
 - [x] **Auth** - JWT login, global role guard, argon2 hashing (`CUSTOMER`,
       `ATTENDANT`, `KITCHEN`, `MANAGER`, `ADMIN`). Refresh-token rotation
       and user registration still pending.
 - [x] **Audit** - `audit_logs` table, `AuditService` with metadata
-      sanitization (password/token/CPF redaction), `AuditLogger` port
-      injected into `SignInUseCase` for `LOGIN_SUCCESS` / `LOGIN_FAILED`.
-      Ready to be injected into future order / payment use cases.
-- [x] **Orders** - channel-aware `POST /api/orders` with decimal-string
-      money, server-side total, server-side `unitPrice` validation against
-      `BusinessUnitMenuItem.customPrice` / `Product.basePrice` (anti-tampering),
-      `Product.isActive` enforcement (inactive products cannot be ordered),
-      attendant role check via `OrderChannel` policies, and `customerId`
-      nullable for anonymous totem orders. Item updates, status transitions,
-      idempotent creation and order reads still pending.
-- [ ] **Payments** - gateway integration (mocked initially), refund flow
-- [ ] **Inventory** - stock, reservations, inventory transactions ledger
+      sanitization (password/token/CPF redaction), `AuditLogger` port injected
+      into the login, order, payment and inventory flows.
+- [x] **Orders** - channel-aware creation, cursor-paginated reads, owner-scoped
+      single read, and a status state machine (optimistic-locked transitions).
+      Decimal-string money, server-side total, `unitPrice` anti-tampering and
+      `Product.isActive` enforcement. Item updates and idempotent creation
+      still pending.
+- [x] **Payments** - mock gateway charge, HMAC-signed webhook that confirms the
+      order in the same transaction, and a sweeper that expires stale
+      `PROCESSING` payments. Refunds still pending.
+- [x] **Inventory** - per-unit stock, an `InventoryTransaction` ledger, atomic
+      deduction on order creation, manual `IN`/`OUT` adjustments, and a
+      `STOCK_ALERT` audit on low balance. Reservations still pending.
 - [ ] **Promotions** - percentage / fixed-amount / free-item discounts
-- [ ] **Loyalty** - points earning (`floor(totalAmount)` per order, conditional
-      on a `LoyaltyAccount` with `consentGiven=true`), redemption with balance
-      validation against `LoyaltyAccount.totalPoints`, and consent tracking
-      (LGPD). The `pointsEarned` hook lives in `CreateOrderUseCase` already.
+- [x] **Loyalty** - auto-enrolment on the first order, consent tracking (LGPD),
+      and `floor(paidAmount / 10)` points credited on approved payments.
+      Redemption (balance validation against `LoyaltyAccount.totalPoints`)
+      still pending.
 
 ---
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,0 +1,119 @@
+# Plano de testes - Raízes do Nordeste
+
+Cenários de smoke test da API que cobrem o fluxo crítico (login, pedido, pagamento,
+estoque, fidelidade) e os principais erros de borda. Cada cenário tem um request
+correspondente na coleção Postman `Raizes do Nordeste - Smoke Tests` (pastas `Positivos`
+e `Negativos`). A pasta `Rota A` roteiriza o fluxo crítico ponta a ponta e a pasta `Setup`
+faz o login de staff.
+
+A coleção versionada está em `postman/raizes-nordeste.postman_collection.json`. Importe esse
+arquivo no Postman (Import) para ter os requests com os scripts de teste já embutidos; ela é
+autossuficiente (usa collection variables, sem environment externo).
+
+## Como a API responde
+
+- Prefixo global: todas as rotas ficam sob `/api`. Base local: `http://localhost:3000/api`.
+- Autenticação: JWT Bearer. `POST /api/auth/login` devolve `{ "access_token": "<jwt>" }`.
+  As rotas protegidas exigem o header `Authorization: Bearer <token>`. São públicas apenas:
+  login, `GET /api/products...` e `POST /api/payments/webhook`.
+- Papéis: `ADMIN`, `MANAGER`, `ATTENDANT`, `KITCHEN`, `CUSTOMER`.
+- Listagens (`GET /api/products...`, `GET /api/orders`) usam envelope paginado
+  `{ data: [...], meta: {...} }`. `GET /api/inventory/:unidade` devolve um array simples.
+- Erros: qualquer resposta 4xx/5xx usa o mesmo envelope:
+  `{ statusCode, message, error, timestamp, path }`. O código vem da taxonomia de erros
+  (`src/shared/errors/errors.type.ts`): `invalid` 422, `not-found` 404, `conflict` 409,
+  `unauthorized` 401, `forbidden` 403, `unavailable` 503. Falha de validação de DTO
+  (class-validator) responde 400.
+
+## Pré-condições para rodar
+
+1. Banco no ar, migrado e populado: `docker compose up -d --wait`, `npm run db:migrate`, `npm run db:seed`.
+2. Definir `PAYMENT_WEBHOOK_SECRET=dev-webhook-secret` no `.env` (hoje ele não está lá). Sem esse
+   valor o guard do webhook responde 401 em qualquer requisição. Reiniciar o servidor depois de
+   adicionar.
+3. O `webhookSecret` da coleção (variável de coleção, default `dev-webhook-secret`) tem que ser
+   exatamente igual ao `PAYMENT_WEBHOOK_SECRET` do servidor.
+4. Servidor rodando: `npm run start:dev`.
+5. Rodar a coleção inteira de cima para baixo (Setup, Positivos, Negativos). `Setup` salva o
+   `staffToken` e `P1` salva o `customerToken`; os demais requests dependem desses tokens e das
+   collection variables encadeadas (orderId, extTransactionId, etc.).
+
+## Dados vindos do seed
+
+| Usuário            | Senha       | Papel    | Observação                    |
+| ------------------ | ----------- | -------- | ----------------------------- |
+| `customer1`        | `password4` | CUSTOMER | dono dos pedidos nos cenários |
+| `davi151413`       | `password2` | ADMIN    | staff (status e estoque)      |
+| `gustavojogadorps` | `password3` | MANAGER  | staff alternativo             |
+
+IDs fixos no seed (os únicos com UUID estável, por isso são usados nos testes):
+
+| Recurso                  | ID                                     | Detalhe                          |
+| ------------------------ | -------------------------------------- | -------------------------------- |
+| Unidade 1 (Rainbow)      | `e36e29da-52ae-49af-ab40-5f1e8b61c8a1` | tem cardápio e estoque           |
+| Produto "Açaí Fitness"   | `cebe6acf-e54e-4842-a8ec-eda9a439ceb5` | no cardápio da unidade 1         |
+| Preço de cardápio (unid. 1) | `22.30`                             | preço autoritativo do item       |
+
+O `unitPrice` enviado no pedido tem que bater com o preço autoritativo de cardápio
+(`customPrice`), senão a criação falha com 422. Por isso os cenários usam `22.30`.
+
+## Cenários positivos
+
+| ID  | Nome                                  | Endpoint                                                        | Pré-condição                                  | Entrada                                                                                   | Resultado esperado                                                       | Evidência (request)   |
+| --- | ------------------------------------- | -------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------- |
+| P1  | Login com credenciais válidas         | `POST /auth/login`                                             | `customer1` no seed                           | `{ username: customer1, password: password4 }`                                           | 200; corpo com `access_token` (string JWT)                               | Positivos/P1          |
+| P2  | Criar pedido válido (canal APP)       | `POST /orders`                                                 | logado como `customer1`; Açaí no cardápio     | Bearer; `businessUnitId` unid. 1; `orderChannel=APP`; item Açaí `quantity=1` `unitPrice=22.30` | 201; `orderStatus=PENDING`; `totalAmount=22.30`; `customerId` preenchido | Positivos/P2          |
+| P3  | Pagar pedido (sucesso)                | `POST /payments` + `POST /payments/webhook` + `GET /orders/:id` | pedido em PENDING (P2)                         | 1) pagamento `{orderId, method:PIX}`; 2) webhook assinado `status=APPROVED`; 3) lê pedido | pagamento 201 `PROCESSING`; webhook 200 `{received:true}`; pedido `CONFIRMED` | Positivos/P3a-c       |
+| P4  | Ler pagamento do pedido               | `GET /orders/:orderId/payment`                                 | pedido pago (P3)                              | Bearer `customer1`                                                                        | 200; pagamento `status=APPROVED`; `orderId` confere                      | Positivos/P4          |
+| P5  | Conta de fidelidade do cliente        | `GET /loyalty/me`                                              | conta criada no 1.º pedido (P2)               | Bearer `customer1`                                                                        | 200; `customerId` presente; `totalPoints` numérico                       | Positivos/P5          |
+| P6  | Atualizar status (PENDING p/ CONFIRMED) | `POST /orders` + `PATCH /orders/:id/status`                  | staff logado (Setup)                          | cria pedido; PATCH `{ orderStatus: CONFIRMED }` com Bearer staff                          | criação 201 `PENDING`; PATCH 200 `CONFIRMED`                             | Positivos/P6a-b       |
+| P7  | Listar cardápio por unidade           | `GET /products/by-business-unit/:bu`                          | unidade 1 com itens                           | sem auth (rota pública)                                                                   | 200; envelope paginado com `data` array                                  | Positivos/P7          |
+| P8  | Filtrar pedidos por canal             | `GET /orders?orderChannel=APP`                                | staff logado                                  | Bearer staff                                                                              | 200; `data` array; todo item com `orderChannel=APP`                      | Positivos/P8          |
+| P9  | Baixa de estoque ao criar pedido      | `GET /inventory/:bu` + `POST /orders` + `GET /inventory/:bu`  | staff lê estoque; produto com saldo           | lê saldo; cria pedido `quantity=1`; lê saldo de novo                                      | saldo final = saldo inicial menos 1                                      | Positivos/P9a-c       |
+
+## Cenários negativos
+
+| ID  | Nome                                  | Endpoint                          | Pré-condição                | Entrada                                                  | Resultado esperado                | Evidência (request)   |
+| --- | ------------------------------------- | --------------------------------- | --------------------------- | ------------------------------------------------------- | --------------------------------- | --------------------- |
+| N1  | Login com senha errada                | `POST /auth/login`                | `customer1` existe          | senha incorreta com 8+ caracteres (`senhaerrada`)       | 401                               | Negativos/N1          |
+| N2  | Login com senha curta                 | `POST /auth/login`                | nenhuma                     | senha com menos de 8 caracteres (`123`)                 | 400 (validação `MinLength(8)`)    | Negativos/N2          |
+| N3  | Criar pedido sem JWT                  | `POST /orders`                    | nenhuma                     | sem header `Authorization`                              | 401                               | Negativos/N3          |
+| N4  | Criar pedido sem `orderChannel`       | `POST /orders`                    | logado como `customer1`     | body sem `orderChannel`                                 | 400 (canalPedido obrigatório)     | Negativos/N4          |
+| N5  | Criar pedido com quantidade inválida  | `POST /orders`                    | logado como `customer1`     | item com `quantity: 0`                                  | 400 (`@Min(1)`)                   | Negativos/N5          |
+| N6  | Produto inexistente no pedido         | `POST /orders`                    | logado como `customer1`     | `productId` UUID válido fora do cardápio                | 404                               | Negativos/N6          |
+| N7  | Preço divergente do cardápio          | `POST /orders`                    | logado como `customer1`     | `unitPrice` diferente do `customPrice` (`1.00`)         | 422                               | Negativos/N7          |
+| N8  | Estoque insuficiente                  | `POST /orders`                    | logado como `customer1`     | `quantity: 999999`, `unitPrice=22.30`                   | 422 (ver nota sobre 422 vs 409)   | Negativos/N8          |
+| N9  | Customer em rota de staff             | `GET /orders`                     | logado como `customer1`     | Bearer `customer1` (rota é staff-only)                  | 403                               | Negativos/N9          |
+| N10 | Pagar pedido já pago                  | `POST /payments` (2x)             | pedido novo em PENDING      | paga a mesma ordem duas vezes seguidas                  | 1.ª 201; 2.ª 422                  | Negativos/N10a-c      |
+| N11 | Webhook com assinatura inválida       | `POST /payments/webhook`          | nenhuma                     | header `x-webhook-signature` inválido                   | 401                               | Negativos/N11         |
+| N12 | Pagamento recusado                    | `POST /orders` + `POST /payments` + webhook `REFUSED` + `GET /orders/:id` | pedido novo em PENDING | webhook assinado `status=REFUSED`                       | webhook 200; pedido continua `PENDING` | Negativos/N12a-d  |
+
+## Cobertura da matriz do roteiro (seção 8.3)
+
+- a) Autenticação/autorização: login (P1), sem token 401 (N3), perfil sem permissão 403 (N9).
+- b) Validação: campo obrigatório ausente (N4), formato/tipo inválido (N2 senha curta, N5 quantidade).
+- c) Regras de negócio: pedido válido 201 (P2), produto inexistente 404 (N6), estoque insuficiente (N8).
+- d) Pagamento mock: aprovado e status atualizado (P3), recusado e status coerente (N12).
+- e) Logs/auditoria: ver nota abaixo.
+
+São 9 cenários positivos e 12 negativos (mínimo do roteiro: 6 positivos, 4 negativos).
+
+## Notas
+
+- Os nomes de status do roteiro de sprint (CRIADO, EM_PREPARO, ENTREGUE) eram provisórios.
+  O enum implementado é `PENDING`, `CONFIRMED`, `PREPARING`, `READY`, `DELIVERED`, `CANCELLED`.
+  A máquina de estados exige `CONFIRMED` antes de `PREPARING`, então a transição válida a
+  partir do estado inicial é `PENDING` para `CONFIRMED` (usada em P6). Ir de `PENDING` direto
+  para `DELIVERED` é uma transição inválida e responde 422.
+- Em N1 a senha incorreta precisa ter 8+ caracteres. Senha curta cai na validação do DTO e
+  responde 400 (é exatamente o que N2 prova). Por isso há dois cenários de login com falha.
+- Estoque insuficiente (N8) responde 422, não 409. `InsufficientStockError` é um `DomainError`
+  com `kind = invalid`, e o filtro global mapeia `invalid` para 422. O roteiro pede "409 ou
+  regra equivalente": adotamos 422 por coerência com a taxonomia de erros (uma operação de
+  domínio inválida, não um conflito de recurso). Mesmo motivo do preço divergente (N7).
+- Logs/auditoria (item 8.3e): não há endpoint de auditoria exposto. A troca de status grava
+  `updatedById` no pedido (visível no response de P6 / `GET /orders/:id`) e o `GlobalErrorFilter`
+  registra toda resposta 4xx/5xx no log do servidor (método, path, mensagem). A evidência é o
+  log do servidor, não a coleção.
+- O fluxo crítico (P1 a P3, espelhado na pasta `Rota A`) também é coberto por teste e2e
+  automatizado em `test/payments.e2e-spec.ts`.

--- a/postman/raizes-nordeste.postman_collection.json
+++ b/postman/raizes-nordeste.postman_collection.json
@@ -1,0 +1,1237 @@
+{
+  "info": {
+    "_postman_id": "13db659f-adbb-4881-a8f6-eb895cd9c993",
+    "name": "Raizes do Nordeste - Smoke Tests",
+    "description": "Smoke tests autossuficientes (collection variables, sem environment externo).\n\nPastas: Setup, Positivos (9 cenarios), Negativos (12 cenarios) e Rota A (fluxo critico scriptado, ja validado).\n\nAntes de rodar: db migrado+seed, PAYMENT_WEBHOOK_SECRET=dev-webhook-secret no .env do servidor, servidor de pe.\n\nRodar na ordem (de cima pra baixo): Setup e P1 populam os tokens que o resto usa.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Setup",
+      "description": "Pre-condicoes + login de staff. Roda primeiro: salva staffToken (ADMIN davi151413) usado pelas rotas de staff (trocar status de pedido, ler estoque). Requer db migrado+seed, PAYMENT_WEBHOOK_SECRET=dev-webhook-secret no servidor (igual a variavel webhookSecret) e servidor de pe.",
+      "item": [
+        {
+          "name": "Setup - Login staff (ADMIN)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('staffToken', json.access_token);",
+                  "pm.test('tem access_token', function () { pm.expect(json.access_token).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"username\": \"davi151413\",\n    \"password\": \"password2\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Positivos",
+      "description": "Cenarios do fluxo esperado. Rode de cima pra baixo: P1 salva customerToken e os pedidos/pagamentos encadeiam por collection variables. Cobre login (P1), criar pedido (P2), pagar com webhook auto-assinado (P3a-c), ler pagamento (P4), fidelidade (P5), trocar status como staff (P6a-b), cardapio paginado (P7), filtro por canal (P8) e baixa de estoque (P9a-c).",
+      "item": [
+        {
+          "name": "P1 - Login (customer) com credenciais validas",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('customerToken', json.access_token);",
+                  "pm.test('tem access_token', function () { pm.expect(json.access_token).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"username\": \"customer1\",\n    \"password\": \"password4\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P2 - Criar pedido valido (APP)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('orderId', json.id);",
+                  "pm.collectionVariables.set('paymentAmount', json.totalAmount);",
+                  "pm.test('pedido PENDING', function () { pm.expect(json.orderStatus).to.eql('PENDING'); });",
+                  "pm.test('total 22.30', function () { pm.expect(json.totalAmount).to.eql('22.30'); });",
+                  "pm.test('tem customerId', function () { pm.expect(json.customerId).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P3a - Criar pagamento (PIX)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('extTransactionId', json.extTransactionId);",
+                  "pm.collectionVariables.set('paymentAmount', json.amount);",
+                  "pm.test('pagamento PROCESSING', function () { pm.expect(json.status).to.eql('PROCESSING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"orderId\": \"{{orderId}}\",\n    \"method\": \"PIX\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P3b - Webhook do gateway (APPROVED)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// assina o webhook com o mesmo HMAC que o guard verifica: ts.extId.status.amount",
+                  "var ts = String(Math.floor(Date.now() / 1000));",
+                  "var status = 'APPROVED';",
+                  "var extId = pm.collectionVariables.get('extTransactionId');",
+                  "var amount = pm.collectionVariables.get('paymentAmount');",
+                  "var secret = pm.collectionVariables.get('webhookSecret');",
+                  "var canonical = ts + '.' + extId + '.' + status + '.' + amount;",
+                  "var sig = CryptoJS.HmacSHA256(canonical, secret).toString(CryptoJS.enc.Hex);",
+                  "pm.collectionVariables.set('webhookTimestamp', ts);",
+                  "pm.collectionVariables.set('webhookSignature', sig);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('recebido', function () { pm.expect(pm.response.json()).to.eql({ received: true }); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-webhook-signature", "value": "{{webhookSignature}}" },
+              { "key": "x-webhook-timestamp", "value": "{{webhookTimestamp}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"extTransactionId\": \"{{extTransactionId}}\",\n    \"status\": \"APPROVED\",\n    \"amount\": \"{{paymentAmount}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments/webhook",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "webhook"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P3c - Conferir pedido CONFIRMED",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('pedido CONFIRMED', function () { pm.expect(pm.response.json().orderStatus).to.eql('CONFIRMED'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{customerToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/orders/{{orderId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders", "{{orderId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P4 - Ler pagamento do pedido (APPROVED)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var json = pm.response.json();",
+                  "pm.test('pagamento APPROVED', function () { pm.expect(json.status).to.eql('APPROVED'); });",
+                  "pm.test('pagamento da ordem', function () { pm.expect(json.orderId).to.eql(pm.collectionVariables.get('orderId')); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{customerToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/orders/{{orderId}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders", "{{orderId}}", "payment"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P5 - Conta de fidelidade do customer",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var json = pm.response.json();",
+                  "pm.test('tem customerId', function () { pm.expect(json.customerId).to.be.a('string'); });",
+                  "pm.test('totalPoints e numero', function () { pm.expect(json.totalPoints).to.be.a('number'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{customerToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/loyalty/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["loyalty", "me"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P6a - Criar pedido para troca de status",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('orderId2', json.id);",
+                  "pm.test('pedido PENDING', function () { pm.expect(json.orderStatus).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P6b - Atualizar status (PENDING para CONFIRMED)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('pedido CONFIRMED', function () { pm.expect(pm.response.json().orderStatus).to.eql('CONFIRMED'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{staffToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"orderStatus\": \"CONFIRMED\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders/{{orderId2}}/status",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders", "{{orderId2}}", "status"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P7 - Listar cardapio por unidade (paginado)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('data e array', function () { pm.expect(pm.response.json().data).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/products/by-business-unit/{{businessUnitId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["products", "by-business-unit", "{{businessUnitId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P8 - Listar pedidos filtrando por canal (staff)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var json = pm.response.json();",
+                  "pm.test('data e array', function () { pm.expect(json.data).to.be.an('array'); });",
+                  "pm.test('todos do canal APP', function () { json.data.forEach(function (o) { pm.expect(o.orderChannel).to.eql('APP'); }); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{staffToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/orders?orderChannel=APP",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"],
+              "query": [{ "key": "orderChannel", "value": "APP" }]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P9a - Estoque antes",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var rows = pm.response.json();",
+                  "var row = rows.find(function (r) { return r.productId === pm.collectionVariables.get('productId'); });",
+                  "pm.test('produto tem linha de estoque', function () { pm.expect(row).to.be.an('object'); });",
+                  "pm.collectionVariables.set('stockBefore', row.quantity);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{staffToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/inventory/{{businessUnitId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["inventory", "{{businessUnitId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P9b - Criar pedido (baixa estoque)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "pm.collectionVariables.set('orderId3', pm.response.json().id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "P9c - Estoque depois (saldo - 1)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var rows = pm.response.json();",
+                  "var row = rows.find(function (r) { return r.productId === pm.collectionVariables.get('productId'); });",
+                  "var before = Number(pm.collectionVariables.get('stockBefore'));",
+                  "pm.test('saldo caiu 1', function () { pm.expect(row.quantity).to.eql(before - 1); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{staffToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/inventory/{{businessUnitId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["inventory", "{{businessUnitId}}"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Negativos",
+      "description": "Cenarios de erro/regra. Depende de Setup + P1 (tokens ja populados ao rodar de cima pra baixo). Cobre 401 (senha errada / sem token / webhook mal assinado), 400 (validacao: senha curta, canalPedido ausente, quantidade invalida), 404 (produto fora do cardapio), 422 (preco divergente, estoque insuficiente, pagar duas vezes), 403 (customer em rota de staff) e pagamento recusado (pedido continua PENDING). Obs: estoque insuficiente responde 422 (DomainError kind=invalid), equivalente ao 409 do roteiro.",
+      "item": [
+        {
+          "name": "N1 - Login com senha errada (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 401', function () { pm.response.to.have.status(401); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"username\": \"customer1\",\n    \"password\": \"senhaerrada\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N2 - Login com senha curta (400 validacao)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 400', function () { pm.response.to.have.status(400); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"username\": \"customer1\",\n    \"password\": \"123\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N3 - Criar pedido sem JWT (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 401', function () { pm.response.to.have.status(401); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N4 - Criar pedido sem orderChannel (400 validacao)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 400', function () { pm.response.to.have.status(400); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N5 - Criar pedido com quantidade invalida (400 validacao)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 400', function () { pm.response.to.have.status(400); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 0, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N6 - Produto inexistente no pedido (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 404', function () { pm.response.to.have.status(404); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"11111111-1111-4111-8111-111111111111\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N7 - Preco divergente do cardapio (422)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 422', function () { pm.response.to.have.status(422); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"1.00\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N8 - Estoque insuficiente (422)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 422', function () { pm.response.to.have.status(422); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 999999, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N9 - Customer em rota de staff (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 403', function () { pm.response.to.have.status(403); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{customerToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N10a - Criar pedido para pagar duas vezes",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "pm.collectionVariables.set('orderDoublePayId', pm.response.json().id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N10b - Pagar pedido (1a vez, 201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 201', function () { pm.response.to.have.status(201); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"orderId\": \"{{orderDoublePayId}}\",\n    \"method\": \"PIX\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N10c - Pagar de novo (mesma ordem, 422)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 422', function () { pm.response.to.have.status(422); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"orderId\": \"{{orderDoublePayId}}\",\n    \"method\": \"PIX\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N11 - Webhook com assinatura invalida (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": ["pm.test('status 401', function () { pm.response.to.have.status(401); });"]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-webhook-signature", "value": "deadbeef" },
+              { "key": "x-webhook-timestamp", "value": "1700000000" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"extTransactionId\": \"{{extTransactionId}}\",\n    \"status\": \"APPROVED\",\n    \"amount\": \"{{paymentAmount}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments/webhook",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "webhook"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N12a - Criar pedido para pagamento recusado",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "pm.collectionVariables.set('orderRefusedId', pm.response.json().id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N12b - Criar pagamento (PIX)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('extTransactionRefusedId', json.extTransactionId);",
+                  "pm.collectionVariables.set('paymentAmount', json.amount);",
+                  "pm.test('pagamento PROCESSING', function () { pm.expect(json.status).to.eql('PROCESSING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"orderId\": \"{{orderRefusedId}}\",\n    \"method\": \"PIX\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N12c - Webhook do gateway (REFUSED)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// mesmo HMAC do guard, agora com status REFUSED",
+                  "var ts = String(Math.floor(Date.now() / 1000));",
+                  "var status = 'REFUSED';",
+                  "var extId = pm.collectionVariables.get('extTransactionRefusedId');",
+                  "var amount = pm.collectionVariables.get('paymentAmount');",
+                  "var secret = pm.collectionVariables.get('webhookSecret');",
+                  "var canonical = ts + '.' + extId + '.' + status + '.' + amount;",
+                  "var sig = CryptoJS.HmacSHA256(canonical, secret).toString(CryptoJS.enc.Hex);",
+                  "pm.collectionVariables.set('webhookTimestamp', ts);",
+                  "pm.collectionVariables.set('webhookSignature', sig);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('recebido', function () { pm.expect(pm.response.json()).to.eql({ received: true }); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-webhook-signature", "value": "{{webhookSignature}}" },
+              { "key": "x-webhook-timestamp", "value": "{{webhookTimestamp}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"extTransactionId\": \"{{extTransactionRefusedId}}\",\n    \"status\": \"REFUSED\",\n    \"amount\": \"{{paymentAmount}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments/webhook",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "webhook"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "N12d - Pedido continua PENDING (nao confirmou)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('pedido ainda PENDING', function () { pm.expect(pm.response.json().orderStatus).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{customerToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/orders/{{orderRefusedId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders", "{{orderRefusedId}}"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Rota A - Fluxo critico (login, pedido, pagamento)",
+      "description": "Fluxo critico P1 a P3, scripted: roda de cima pra baixo no Runner.\n\nCada request captura o que o proximo precisa nas collection variables; o webhook se autoassina (HMAC com webhookSecret).\n\nPre-condicoes: db seedado, PAYMENT_WEBHOOK_SECRET=dev-webhook-secret no servidor (igual a variavel webhookSecret), servidor de pe.",
+      "item": [
+        {
+          "name": "A1 - Login (customer)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('customerToken', json.access_token);",
+                  "pm.test('tem access_token', function () { pm.expect(json.access_token).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"username\": \"customer1\",\n    \"password\": \"password4\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "A2 - Criar pedido (APP)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('orderId', json.id);",
+                  "pm.collectionVariables.set('paymentAmount', json.totalAmount);",
+                  "pm.test('pedido PENDING', function () { pm.expect(json.orderStatus).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"businessUnitId\": \"{{businessUnitId}}\",\n    \"orderChannel\": \"APP\",\n    \"orderItems\": [\n        { \"productId\": \"{{productId}}\", \"quantity\": 1, \"unitPrice\": \"{{unitPrice}}\" }\n    ]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/orders",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "A3a - Criar pagamento (PIX)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 201', function () { pm.response.to.have.status(201); });",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('extTransactionId', json.extTransactionId);",
+                  "pm.collectionVariables.set('paymentAmount', json.amount);",
+                  "pm.test('pagamento PROCESSING', function () { pm.expect(json.status).to.eql('PROCESSING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{customerToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"orderId\": \"{{orderId}}\",\n    \"method\": \"PIX\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "A3b - Webhook do gateway (APPROVED)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// assina o webhook com o mesmo HMAC que o guard verifica: ts.extId.status.amount",
+                  "var ts = String(Math.floor(Date.now() / 1000));",
+                  "var status = 'APPROVED';",
+                  "var extId = pm.collectionVariables.get('extTransactionId');",
+                  "var amount = pm.collectionVariables.get('paymentAmount');",
+                  "var secret = pm.collectionVariables.get('webhookSecret');",
+                  "var canonical = ts + '.' + extId + '.' + status + '.' + amount;",
+                  "var sig = CryptoJS.HmacSHA256(canonical, secret).toString(CryptoJS.enc.Hex);",
+                  "pm.collectionVariables.set('webhookTimestamp', ts);",
+                  "pm.collectionVariables.set('webhookSignature', sig);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('recebido', function () { pm.expect(pm.response.json()).to.eql({ received: true }); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-webhook-signature", "value": "{{webhookSignature}}" },
+              { "key": "x-webhook-timestamp", "value": "{{webhookTimestamp}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"extTransactionId\": \"{{extTransactionId}}\",\n    \"status\": \"APPROVED\",\n    \"amount\": \"{{paymentAmount}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments/webhook",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "webhook"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "A3c - Conferir pedido CONFIRMED",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('pedido CONFIRMED', function () { pm.expect(pm.response.json().orderStatus).to.eql('CONFIRMED'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{customerToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/orders/{{orderId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["orders", "{{orderId}}"]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ],
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:3000/api" },
+    { "key": "webhookSecret", "value": "dev-webhook-secret" },
+    { "key": "businessUnitId", "value": "e36e29da-52ae-49af-ab40-5f1e8b61c8a1" },
+    { "key": "productId", "value": "cebe6acf-e54e-4842-a8ec-eda9a439ceb5" },
+    { "key": "unitPrice", "value": "22.30" },
+    { "key": "customerToken", "value": "" },
+    { "key": "staffToken", "value": "" },
+    { "key": "orderId", "value": "" },
+    { "key": "orderId2", "value": "" },
+    { "key": "orderId3", "value": "" },
+    { "key": "orderDoublePayId", "value": "" },
+    { "key": "orderRefusedId", "value": "" },
+    { "key": "extTransactionId", "value": "" },
+    { "key": "extTransactionRefusedId", "value": "" },
+    { "key": "paymentAmount", "value": "" },
+    { "key": "stockBefore", "value": "" },
+    { "key": "webhookSignature", "value": "" },
+    { "key": "webhookTimestamp", "value": "" }
+  ]
+}


### PR DESCRIPTION
## What

- **README.md** — reflects that orders, payments (HMAC webhook + stale-payment sweeper), inventory and loyalty now have application code shipped; promotions is the only pending context. Documents the new `PAYMENT_WEBHOOK_SECRET` env var (guard fails closed when unset) and lists the new orders/payments e2e suites.
- **docs/TESTS.md** — critical-flow smoke-test scenarios (positive + negative) mapped to the Postman collection.
- **postman/raizes-nordeste.postman_collection.json** — versioned, self-contained collection with embedded test scripts.

## Why

Docs were lagging behind the code: inventory, payments and loyalty are shipped but the README still described them as planned. Adds a reproducible smoke-test path for the critical flow.

## Notes

Docs/tooling only — no production code touched.