### PR TITLE
feat(loyalty): add loyalty points redemption as order discount

### DIFF
--- a/src/modules/loyalty/application/errors/points-redemption-conflict.error.ts
+++ b/src/modules/loyalty/application/errors/points-redemption-conflict.error.ts
@@ -1,0 +1,14 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/**
+ * The optimistic debit lost a race: a concurrent redemption drained the balance
+ * between the read and the conditional UPDATE, so the guarded decrement matched no
+ * row. CONFLICT (409) tells the client to retry with a fresh balance. Also covers
+ * the duplicate-REDEEM-per-order unique violation (one redemption per order).
+ */
+export class PointsRedemptionConflictError extends ApplicationError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.CONFLICT, message, options);
+  }
+}

--- a/src/modules/loyalty/application/ports/loyalty-redemption.port.ts
+++ b/src/modules/loyalty/application/ports/loyalty-redemption.port.ts
@@ -1,0 +1,40 @@
+import type { TransactionContext } from '@shared/transaction/transaction-runner.port';
+
+export const LOYALTY_REDEMPTION = Symbol('LoyaltyRedemption');
+
+export interface QuoteDiscountInput {
+  customerId: string;
+  /** Points the customer asked to spend; always positive when this port is called. */
+  points: number;
+  /** Gross items subtotal as a decimal string: the redeem discount may not exceed it. */
+  subtotal: string;
+}
+
+export interface RedeemForOrderInput {
+  customerId: string;
+  orderId: string;
+  /** Points the customer asked to spend; always positive when this port is called. */
+  points: number;
+  /** Gross items subtotal as a decimal string: the redeem discount may not exceed it. */
+  subtotal: string;
+}
+
+/**
+ * Capability published by the loyalty context for the orders context to consume.
+ * Orders never touches the loyalty domain directly - the points-to-money rate and
+ * every redemption rule live behind this port.
+ *
+ * Two-step because the order id is DB-generated: the order needs its authoritative
+ * (discounted) total before insert, but the REDEEM transaction row needs the order
+ * id. So `quoteDiscount` validates and prices the redemption (read-only) to set the
+ * total, then `redeemForOrder` debits once the id exists. Both run inside the
+ * order-creation transaction; the deterministic discount cannot drift between them.
+ * Unlike EARN, redemption is not best-effort: insufficient balance, a non-eligible
+ * account or a concurrent debit must fail the order, not be swallowed.
+ */
+export interface LoyaltyRedemption {
+  /** Validates eligibility/balance/ceiling and returns the discount as a decimal string. No write. */
+  quoteDiscount(input: QuoteDiscountInput, tx: TransactionContext): Promise<string>;
+  /** Debits the points (REDEEM + balance decrement) keyed to the order; returns the discount. */
+  redeemForOrder(input: RedeemForOrderInput, tx: TransactionContext): Promise<string>;
+}

--- a/src/modules/loyalty/application/use-cases/redeem-points.use-case.spec.ts
+++ b/src/modules/loyalty/application/use-cases/redeem-points.use-case.spec.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { RedeemPointsUseCase } from './redeem-points.use-case';
+import type {
+  EarnPointsInput,
+  LoyaltyRepository,
+  RedeemPointsInput,
+} from '../../domain/repositories/loyalty.repository';
+import { LoyaltyAccount } from '../../domain/entities/loyalty-account.entity';
+import { InsufficientPointsError } from '../../domain/errors/insufficient-points.error';
+import { PointsRedemptionConflictError } from '../errors/points-redemption-conflict.error';
+import type { TransactionContext } from '@shared/transaction/transaction-runner.port';
+
+const TX = Symbol('tx');
+
+/**
+ * In-memory LoyaltyRepository keyed by customerId. redeem() really decrements the
+ * stored balance so the tests exercise the debit, and it mirrors the prisma repo's
+ * optimistic guard: a conditional decrement that throws CONFLICT (never goes
+ * negative) when totalPoints < points. A second REDEEM for the same orderId also
+ * conflicts, matching the unique-per-order rule.
+ */
+class FakeLoyaltyRepository implements LoyaltyRepository {
+  private readonly byCustomerId = new Map<string, LoyaltyAccount>();
+  private readonly redeemedOrderIds = new Set<string>();
+
+  seed(account: LoyaltyAccount): void {
+    this.byCustomerId.set(account.customerId, account);
+  }
+
+  /** Test helper: current balance for assertions on the debit. */
+  balanceOf(customerId: string): number | null {
+    return this.byCustomerId.get(customerId)?.totalPoints ?? null;
+  }
+
+  findByCustomerId(customerId: string): Promise<LoyaltyAccount | null> {
+    return Promise.resolve(this.byCustomerId.get(customerId) ?? null);
+  }
+
+  createIfAbsent(customerId: string): Promise<void> {
+    if (!this.byCustomerId.has(customerId)) {
+      const now = new Date();
+      this.byCustomerId.set(
+        customerId,
+        new LoyaltyAccount(`la-${customerId}`, customerId, 0, false, null, now, now),
+      );
+    }
+    return Promise.resolve();
+  }
+
+  earn(input: EarnPointsInput): Promise<void> {
+    const account = this.requireAccount(input.loyaltyAccountId);
+    this.replace(account, account.totalPoints + input.points);
+    return Promise.resolve();
+  }
+
+  redeem(input: RedeemPointsInput, _tx: TransactionContext): Promise<void> {
+    void _tx;
+    if (this.redeemedOrderIds.has(input.orderId)) {
+      throw new PointsRedemptionConflictError(`Order ${input.orderId} already has a redemption.`);
+    }
+    const account = this.requireAccount(input.loyaltyAccountId);
+    // Conditional decrement: the guard the prisma repo enforces in SQL.
+    if (account.totalPoints < input.points) {
+      throw new PointsRedemptionConflictError(
+        `Insufficient points to redeem ${input.points} for account ${input.loyaltyAccountId} (concurrent debit).`,
+      );
+    }
+    this.replace(account, account.totalPoints - input.points);
+    this.redeemedOrderIds.add(input.orderId);
+    return Promise.resolve();
+  }
+
+  private requireAccount(loyaltyAccountId: string): LoyaltyAccount {
+    for (const account of this.byCustomerId.values()) {
+      if (account.id === loyaltyAccountId) {
+        return account;
+      }
+    }
+    throw new Error(`Fake has no account ${loyaltyAccountId}`);
+  }
+
+  private replace(account: LoyaltyAccount, totalPoints: number): void {
+    this.byCustomerId.set(
+      account.customerId,
+      new LoyaltyAccount(
+        account.id,
+        account.customerId,
+        totalPoints,
+        account.consentGiven,
+        account.consentDate,
+        account.createdAt,
+        new Date(),
+      ),
+    );
+  }
+}
+
+const account = (consentGiven: boolean, totalPoints: number): LoyaltyAccount =>
+  new LoyaltyAccount('la-1', 'c-1', totalPoints, consentGiven, null, new Date(), new Date());
+
+describe('RedeemPointsUseCase', () => {
+  let repo: FakeLoyaltyRepository;
+  let useCase: RedeemPointsUseCase;
+
+  beforeEach(() => {
+    repo = new FakeLoyaltyRepository();
+    useCase = new RedeemPointsUseCase(repo);
+  });
+
+  describe('redeemForOrder', () => {
+    it('debits the points from the stored balance and returns the discount when eligible', async () => {
+      repo.seed(account(true, 100));
+
+      const discount = await useCase.redeemForOrder(
+        { customerId: 'c-1', orderId: 'o-1', points: 100, subtotal: '50.00' },
+        TX,
+      );
+
+      expect(discount).toBe('10.00');
+      expect(repo.balanceOf('c-1')).toBe(0);
+    });
+
+    it('leaves the remaining balance intact after a partial redemption', async () => {
+      repo.seed(account(true, 100));
+
+      await useCase.redeemForOrder(
+        { customerId: 'c-1', orderId: 'o-1', points: 40, subtotal: '50.00' },
+        TX,
+      );
+
+      expect(repo.balanceOf('c-1')).toBe(60);
+    });
+
+    it('rejects with InsufficientPointsError and never debits when the balance is too low', async () => {
+      repo.seed(account(true, 40));
+
+      await expect(
+        useCase.redeemForOrder(
+          { customerId: 'c-1', orderId: 'o-1', points: 50, subtotal: '50.00' },
+          TX,
+        ),
+      ).rejects.toBeInstanceOf(InsufficientPointsError);
+      expect(repo.balanceOf('c-1')).toBe(40);
+    });
+
+    it('permite resgatar exatamente o saldo total e zera a conta', async () => {
+      repo.seed(account(true, 50));
+
+      const discount = await useCase.redeemForOrder(
+        { customerId: 'c-1', orderId: 'o-1', points: 50, subtotal: '50.00' },
+        TX,
+      );
+
+      expect(discount).toBe('5.00');
+      expect(repo.balanceOf('c-1')).toBe(0);
+    });
+
+    it('rejeita 1 ponto acima do saldo', async () => {
+      repo.seed(account(true, 50));
+
+      await expect(
+        useCase.redeemForOrder(
+          { customerId: 'c-1', orderId: 'o-1', points: 51, subtotal: '50.00' },
+          TX,
+        ),
+      ).rejects.toBeInstanceOf(InsufficientPointsError);
+      expect(repo.balanceOf('c-1')).toBe(50);
+    });
+
+    it('rejects without consent (LGPD gate)', async () => {
+      repo.seed(account(false, 100));
+
+      await expect(
+        useCase.redeemForOrder(
+          { customerId: 'c-1', orderId: 'o-1', points: 50, subtotal: '50.00' },
+          TX,
+        ),
+      ).rejects.toBeInstanceOf(InsufficientPointsError);
+      expect(repo.balanceOf('c-1')).toBe(100);
+    });
+
+    it('rejects when the customer has no account', async () => {
+      await expect(
+        useCase.redeemForOrder(
+          { customerId: 'c-1', orderId: 'o-1', points: 50, subtotal: '50.00' },
+          TX,
+        ),
+      ).rejects.toBeInstanceOf(InsufficientPointsError);
+    });
+
+    it('rejects when the converted discount exceeds the order subtotal (ceiling)', async () => {
+      repo.seed(account(true, 1000));
+
+      await expect(
+        useCase.redeemForOrder(
+          // 1000 points = R$100.00 > R$50.00 subtotal
+          { customerId: 'c-1', orderId: 'o-1', points: 1000, subtotal: '50.00' },
+          TX,
+        ),
+      ).rejects.toBeInstanceOf(InsufficientPointsError);
+      expect(repo.balanceOf('c-1')).toBe(1000);
+    });
+
+    it('propagates a repository conflict (duplicate redemption for the order) without swallowing it', async () => {
+      repo.seed(account(true, 100));
+      await useCase.redeemForOrder(
+        { customerId: 'c-1', orderId: 'o-1', points: 40, subtotal: '50.00' },
+        TX,
+      );
+
+      // A second debit keyed to the same order is the optimistic CONFLICT.
+      await expect(
+        useCase.redeemForOrder(
+          { customerId: 'c-1', orderId: 'o-1', points: 40, subtotal: '50.00' },
+          TX,
+        ),
+      ).rejects.toBeInstanceOf(PointsRedemptionConflictError);
+    });
+  });
+
+  describe('quoteDiscount', () => {
+    it('prices the redemption without writing', async () => {
+      repo.seed(account(true, 100));
+
+      const discount = await useCase.quoteDiscount(
+        { customerId: 'c-1', points: 100, subtotal: '50.00' },
+        TX,
+      );
+
+      expect(discount).toBe('10.00');
+      expect(repo.balanceOf('c-1')).toBe(100);
+    });
+
+    it('rejects an ineligible redemption with InsufficientPointsError', async () => {
+      repo.seed(account(true, 10));
+
+      await expect(
+        useCase.quoteDiscount({ customerId: 'c-1', points: 50, subtotal: '50.00' }, TX),
+      ).rejects.toBeInstanceOf(InsufficientPointsError);
+    });
+  });
+});

--- a/src/modules/loyalty/application/use-cases/redeem-points.use-case.ts
+++ b/src/modules/loyalty/application/use-cases/redeem-points.use-case.ts
@@ -1,0 +1,79 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Big from 'big.js';
+import type { TransactionContext } from '@shared/transaction/transaction-runner.port';
+import { LoyaltyAccount } from '../../domain/entities/loyalty-account.entity';
+import { InsufficientPointsError } from '../../domain/errors/insufficient-points.error';
+import {
+  LOYALTY_REPOSITORY,
+  type LoyaltyRepository,
+} from '../../domain/repositories/loyalty.repository';
+import type {
+  LoyaltyRedemption,
+  QuoteDiscountInput,
+  RedeemForOrderInput,
+} from '../ports/loyalty-redemption.port';
+
+/**
+ * Implements the LOYALTY_REDEMPTION port: converts points to a money discount at the
+ * redeem rate (1 point = R$0.10) and debits them inside the order-creation tx. Unlike
+ * EARN this never silently no-ops - a missing account, missing consent, too few points
+ * or a discount above the subtotal all reject so the order does not proceed on a bad
+ * redemption. The atomic balance guard lives in the repository (optimistic CONFLICT).
+ */
+@Injectable()
+export class RedeemPointsUseCase implements LoyaltyRedemption {
+  constructor(
+    @Inject(LOYALTY_REPOSITORY)
+    private readonly accounts: LoyaltyRepository,
+  ) {}
+
+  async quoteDiscount(input: QuoteDiscountInput, tx: TransactionContext): Promise<string> {
+    const { discount } = await this.resolveRedemption(input, tx);
+    return discount;
+  }
+
+  async redeemForOrder(input: RedeemForOrderInput, tx: TransactionContext): Promise<string> {
+    const { account, discount } = await this.resolveRedemption(input, tx);
+
+    await this.accounts.redeem(
+      {
+        loyaltyAccountId: account.id,
+        orderId: input.orderId,
+        points: input.points,
+        description: `Points redeemed for order ${input.orderId}`,
+      },
+      tx,
+    );
+
+    return discount;
+  }
+
+  /**
+   * Shared eligibility + pricing: loads the account, enforces consent/balance/ceiling,
+   * and returns the deterministic discount. The balance check here is a fast-fail for
+   * a precise INVALID; the repository's conditional decrement is the real atomic guard.
+   */
+  private async resolveRedemption(
+    input: QuoteDiscountInput,
+    tx: TransactionContext,
+  ): Promise<{ account: LoyaltyAccount; discount: string }> {
+    const account = await this.accounts.findByCustomerId(input.customerId, tx);
+    if (!account || !account.canRedeem(input.points)) {
+      throw new InsufficientPointsError(
+        `Customer ${input.customerId} cannot redeem ${input.points} points.`,
+      );
+    }
+
+    const discount = LoyaltyAccount.discountForPoints(input.points);
+    // Ceiling: points may not buy more than the order is worth. Order.computeTotal
+    // also clamps to [0, subtotal] as a net, but rejecting here gives a precise
+    // INVALID instead of letting an over-redemption slip toward the order total.
+    if (new Big(discount).gt(new Big(input.subtotal))) {
+      throw new InsufficientPointsError(
+        `Redeeming ${input.points} points (R$${discount}) exceeds the order subtotal R$${input.subtotal}.`,
+      );
+    }
+
+    return { account, discount };
+  }
+}

--- a/src/modules/loyalty/domain/entities/loyalty-account.entity.spec.ts
+++ b/src/modules/loyalty/domain/entities/loyalty-account.entity.spec.ts
@@ -4,6 +4,9 @@ import { LoyaltyAccount } from './loyalty-account.entity';
 const buildAccount = (consentGiven: boolean): LoyaltyAccount =>
   new LoyaltyAccount('la-1', 'c-1', 0, consentGiven, null, new Date(), new Date());
 
+const buildAccountWith = (consentGiven: boolean, totalPoints: number): LoyaltyAccount =>
+  new LoyaltyAccount('la-1', 'c-1', totalPoints, consentGiven, null, new Date(), new Date());
+
 describe('LoyaltyAccount', () => {
   describe('canEarn', () => {
     it('earns only with consent given', () => {
@@ -22,6 +25,39 @@ describe('LoyaltyAccount', () => {
       ['100.00', 10],
     ])('floor(%s / 10) = %i points', (amount, expected) => {
       expect(LoyaltyAccount.pointsForAmount(amount)).toBe(expected);
+    });
+  });
+
+  describe('canRedeem', () => {
+    it('redeems when consent is given and the balance covers the points', () => {
+      expect(buildAccountWith(true, 100).canRedeem(100)).toBe(true);
+      expect(buildAccountWith(true, 100).canRedeem(50)).toBe(true);
+    });
+
+    it('refuses without consent even with enough points', () => {
+      expect(buildAccountWith(false, 100).canRedeem(50)).toBe(false);
+    });
+
+    it('refuses when the balance is below the requested points', () => {
+      expect(buildAccountWith(true, 49).canRedeem(50)).toBe(false);
+    });
+
+    it('refuses non-positive or non-integer point amounts', () => {
+      expect(buildAccountWith(true, 100).canRedeem(0)).toBe(false);
+      expect(buildAccountWith(true, 100).canRedeem(-10)).toBe(false);
+      expect(buildAccountWith(true, 100).canRedeem(1.5)).toBe(false);
+    });
+  });
+
+  describe('discountForPoints', () => {
+    it.each([
+      [100, '10.00'],
+      [1, '0.10'],
+      [150, '15.00'],
+      [0, '0.00'],
+      [7, '0.70'],
+    ])('%i points = R$%s at 1 point = R$0.10', (points, expected) => {
+      expect(LoyaltyAccount.discountForPoints(points)).toBe(expected);
     });
   });
 });

--- a/src/modules/loyalty/domain/entities/loyalty-account.entity.ts
+++ b/src/modules/loyalty/domain/entities/loyalty-account.entity.ts
@@ -3,6 +3,9 @@ import Big from 'big.js';
 /** Earning rate: 1 point per R$10 paid, fraction discarded (RN-31). */
 const EARN_RATE_BRL_PER_POINT = 10;
 
+/** Redemption rate: 1 point = R$0.10, mirroring the earn rate (1 point per R$10). */
+const REDEEM_RATE_BRL_PER_POINT = '0.10';
+
 export class LoyaltyAccount {
   constructor(
     public readonly id: string,
@@ -26,5 +29,22 @@ export class LoyaltyAccount {
   /** floor(amount / 10): R$25.00 -> 2 points. Amount is a decimal string, never a number. */
   static pointsForAmount(totalAmount: string): number {
     return Number(new Big(totalAmount).div(EARN_RATE_BRL_PER_POINT).round(0, Big.roundDown));
+  }
+
+  /**
+   * Can these points be redeemed now: consent given and the balance covers them.
+   * Points must be a positive integer; zero or negative is not redeemable.
+   * TODO(loyalty-expire): once EXPIRE ships, totalPoints already nets expired points
+   * out, so no extra guard is needed here.
+   */
+  canRedeem(points: number): boolean {
+    return (
+      this.consentGiven && Number.isInteger(points) && points > 0 && this.totalPoints >= points
+    );
+  }
+
+  /** Money value of points at the redeem rate: 150 points -> R$15.00. Returns a decimal string. */
+  static discountForPoints(points: number): string {
+    return new Big(points).times(REDEEM_RATE_BRL_PER_POINT).toFixed(2);
   }
 }

--- a/src/modules/loyalty/domain/errors/insufficient-points.error.ts
+++ b/src/modules/loyalty/domain/errors/insufficient-points.error.ts
@@ -1,0 +1,13 @@
+import { DomainError } from '@shared/errors/domain/domain.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/**
+ * A redemption asked for more points than the account can give (no consent, balance
+ * too low, or non-positive amount). A client-correctable request, not a race - the
+ * concurrent-debit loser maps to CONFLICT in persistence instead.
+ */
+export class InsufficientPointsError extends DomainError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.INVALID, message, options);
+  }
+}

--- a/src/modules/loyalty/domain/repositories/loyalty.repository.ts
+++ b/src/modules/loyalty/domain/repositories/loyalty.repository.ts
@@ -9,6 +9,14 @@ export interface EarnPointsInput {
   description: string;
 }
 
+export interface RedeemPointsInput {
+  loyaltyAccountId: string;
+  orderId: string;
+  /** Points to debit; always positive (sign convention mirrors EARN). */
+  points: number;
+  description: string;
+}
+
 export interface LoyaltyRepository {
   /** Pass `tx` to read inside an open transaction (read + later write share one snapshot). */
   findByCustomerId(customerId: string, tx?: TransactionContext): Promise<LoyaltyAccount | null>;
@@ -25,6 +33,16 @@ export interface LoyaltyRepository {
    * increment can never land apart.
    */
   earn(input: EarnPointsInput, tx: TransactionContext): Promise<void>;
+  /**
+   * Debits points atomically on the caller's `tx`: inserts the REDEEM
+   * LoyaltyTransaction (points positive) and decrements `totalPoints` with a
+   * conditional UPDATE (totalPoints >= points). The condition is the optimistic
+   * concurrency check: if a concurrent redemption already drained the balance the
+   * decrement matches no row and this throws CONFLICT instead of going negative.
+   * A duplicate REDEEM for the same order (P2002 on orderId+type) also throws
+   * CONFLICT. `tx` is required so the insert and the decrement never land apart.
+   */
+  redeem(input: RedeemPointsInput, tx: TransactionContext): Promise<void>;
 }
 
 export const LOYALTY_REPOSITORY = Symbol('LoyaltyRepository');

--- a/src/modules/loyalty/infrastructure/persistence/prisma-loyalty.repository.spec.ts
+++ b/src/modules/loyalty/infrastructure/persistence/prisma-loyalty.repository.spec.ts
@@ -3,6 +3,7 @@ import { Prisma } from '@prisma/client';
 import { PrismaLoyaltyRepository } from './prisma-loyalty.repository';
 import { PrismaService } from '@shared/infrastructure/prisma/prisma.service';
 import { LoyaltyTransactionType } from '@modules/loyalty/domain/value-objects/loyalty-transaction-type';
+import { PointsRedemptionConflictError } from '@modules/loyalty/application/errors/points-redemption-conflict.error';
 
 // Each delegate method is an async fn; `unknown` args/return keep the cast light while
 // letting mockResolvedValue accept the raw Prisma rows.
@@ -13,6 +14,7 @@ type PrismaMock = {
     findUnique: DelegateFn;
     create: DelegateFn;
     update: DelegateFn;
+    updateMany: DelegateFn;
   };
   loyaltyTransaction: {
     create: DelegateFn;
@@ -26,6 +28,7 @@ const buildPrismaMock = (): PrismaMock => ({
     findUnique: delegateFn(),
     create: delegateFn(),
     update: delegateFn(),
+    updateMany: delegateFn(),
   },
   loyaltyTransaction: {
     create: delegateFn(),
@@ -126,6 +129,63 @@ describe('PrismaLoyaltyRepository', () => {
         where: { id: 'la-1' },
         data: { totalPoints: { increment: 2 } },
       });
+    });
+  });
+
+  describe('redeem', () => {
+    const input = {
+      loyaltyAccountId: 'la-1',
+      orderId: 'o-1',
+      points: 5,
+      description: 'Points redeemed for order o-1',
+    };
+
+    it('records the REDEEM transaction and decrements with the optimistic balance guard', async () => {
+      prisma.loyaltyTransaction.create.mockResolvedValue({});
+      prisma.loyaltyAccount.updateMany.mockResolvedValue({ count: 1 });
+
+      await repo.redeem(input, prisma);
+
+      expect(prisma.loyaltyTransaction.create).toHaveBeenCalledWith({
+        data: {
+          loyaltyAccountId: 'la-1',
+          orderId: 'o-1',
+          type: LoyaltyTransactionType.REDEEM,
+          points: 5,
+          description: 'Points redeemed for order o-1',
+        },
+      });
+      expect(prisma.loyaltyAccount.updateMany).toHaveBeenCalledWith({
+        where: { id: 'la-1', totalPoints: { gte: 5 } },
+        data: { totalPoints: { decrement: 5 } },
+      });
+    });
+
+    it('throws CONFLICT when the conditional decrement matches no row (concurrent debit)', async () => {
+      prisma.loyaltyTransaction.create.mockResolvedValue({});
+      prisma.loyaltyAccount.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(repo.redeem(input, prisma)).rejects.toBeInstanceOf(
+        PointsRedemptionConflictError,
+      );
+    });
+
+    it('maps a duplicate REDEEM per order (P2002) to CONFLICT and never decrements', async () => {
+      prisma.loyaltyTransaction.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('dup', { code: 'P2002', clientVersion: '7' }),
+      );
+
+      await expect(repo.redeem(input, prisma)).rejects.toBeInstanceOf(
+        PointsRedemptionConflictError,
+      );
+      expect(prisma.loyaltyAccount.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('rethrows any other persistence failure on the insert', async () => {
+      const boom = new Error('db down');
+      prisma.loyaltyTransaction.create.mockRejectedValue(boom);
+
+      await expect(repo.redeem(input, prisma)).rejects.toBe(boom);
     });
   });
 });

--- a/src/modules/loyalty/infrastructure/persistence/prisma-loyalty.repository.ts
+++ b/src/modules/loyalty/infrastructure/persistence/prisma-loyalty.repository.ts
@@ -6,8 +6,10 @@ import { LoyaltyAccount } from '@modules/loyalty/domain/entities/loyalty-account
 import {
   EarnPointsInput,
   LoyaltyRepository,
+  RedeemPointsInput,
 } from '@modules/loyalty/domain/repositories/loyalty.repository';
 import { LoyaltyTransactionType } from '@modules/loyalty/domain/value-objects/loyalty-transaction-type';
+import { PointsRedemptionConflictError } from '@modules/loyalty/application/errors/points-redemption-conflict.error';
 
 @Injectable()
 export class PrismaLoyaltyRepository implements LoyaltyRepository {
@@ -57,6 +59,47 @@ export class PrismaLoyaltyRepository implements LoyaltyRepository {
       where: { id: input.loyaltyAccountId },
       data: { totalPoints: { increment: input.points } },
     });
+  }
+
+  async redeem(input: RedeemPointsInput, tx: TransactionContext): Promise<void> {
+    const db = tx as Prisma.TransactionClient;
+
+    // Insert first: the (orderId, type) unique index makes REDEEM idempotent at the
+    // DB level. A second redemption for the same order hits P2002, which we surface
+    // as CONFLICT (the tx rolls back, so no partial debit lands).
+    try {
+      await db.loyaltyTransaction.create({
+        data: {
+          loyaltyAccountId: input.loyaltyAccountId,
+          orderId: input.orderId,
+          type: LoyaltyTransactionType.REDEEM,
+          points: input.points,
+          description: input.description,
+        },
+      });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        throw new PointsRedemptionConflictError(
+          `Order ${input.orderId} already has a points redemption.`,
+          { cause: err },
+        );
+      }
+      throw err;
+    }
+
+    // Optimistic concurrency: the where clause (totalPoints >= points) is the guard.
+    // updateMany reports the affected count, so a concurrent redemption that drained
+    // the balance after our read leaves count = 0 - we throw CONFLICT instead of
+    // letting the balance go negative. No SELECT FOR UPDATE.
+    const { count } = await db.loyaltyAccount.updateMany({
+      where: { id: input.loyaltyAccountId, totalPoints: { gte: input.points } },
+      data: { totalPoints: { decrement: input.points } },
+    });
+    if (count === 0) {
+      throw new PointsRedemptionConflictError(
+        `Insufficient points to redeem ${input.points} for account ${input.loyaltyAccountId} (concurrent debit).`,
+      );
+    }
   }
 
   private toEntity(raw: LoyaltyAccountModel): LoyaltyAccount {

--- a/src/modules/loyalty/loyalty.module.ts
+++ b/src/modules/loyalty/loyalty.module.ts
@@ -4,9 +4,11 @@ import { LOYALTY_REPOSITORY } from './domain/repositories/loyalty.repository';
 import { PrismaLoyaltyRepository } from './infrastructure/persistence/prisma-loyalty.repository';
 import { LOYALTY_ENROLLMENT } from './application/ports/loyalty-enrollment.port';
 import { LOYALTY_EARNING } from './application/ports/loyalty-earning.port';
+import { LOYALTY_REDEMPTION } from './application/ports/loyalty-redemption.port';
 import { GetMyLoyaltyAccountUseCase } from './application/use-cases/get-my-loyalty-account.use-case';
 import { EnrollCustomerUseCase } from './application/use-cases/enroll-customer.use-case';
 import { EarnPointsUseCase } from './application/use-cases/earn-points.use-case';
+import { RedeemPointsUseCase } from './application/use-cases/redeem-points.use-case';
 
 @Module({
   controllers: [LoyaltyController],
@@ -23,8 +25,12 @@ import { EarnPointsUseCase } from './application/use-cases/earn-points.use-case'
       provide: LOYALTY_EARNING,
       useClass: EarnPointsUseCase,
     },
+    {
+      provide: LOYALTY_REDEMPTION,
+      useClass: RedeemPointsUseCase,
+    },
     GetMyLoyaltyAccountUseCase,
   ],
-  exports: [LOYALTY_ENROLLMENT, LOYALTY_EARNING],
+  exports: [LOYALTY_ENROLLMENT, LOYALTY_EARNING, LOYALTY_REDEMPTION],
 })
 export class LoyaltyModule {}

--- a/src/modules/orders/application/errors/points-redemption-requires-customer.error.ts
+++ b/src/modules/orders/application/errors/points-redemption-requires-customer.error.ts
@@ -1,0 +1,13 @@
+import { ApplicationError } from '@shared/errors/application/application.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/**
+ * An order asked to redeem points but resolved to no customer (e.g. an anonymous
+ * channel). Points belong to a loyalty account, so there is nobody to debit - the
+ * request is malformed (422), not a server fault.
+ */
+export class PointsRedemptionRequiresCustomerError extends ApplicationError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.INVALID, message, options);
+  }
+}

--- a/src/modules/orders/application/use-cases/create-order.use-case.spec.ts
+++ b/src/modules/orders/application/use-cases/create-order.use-case.spec.ts
@@ -26,6 +26,80 @@ import {
   LOYALTY_ENROLLMENT,
   type LoyaltyEnrollment,
 } from '@modules/loyalty/application/ports/loyalty-enrollment.port';
+import {
+  LOYALTY_REDEMPTION,
+  type LoyaltyRedemption,
+  type QuoteDiscountInput,
+  type RedeemForOrderInput,
+} from '@modules/loyalty/application/ports/loyalty-redemption.port';
+import { LoyaltyAccount } from '@modules/loyalty/domain/entities/loyalty-account.entity';
+import { PointsRedemptionRequiresCustomerError } from '../errors/points-redemption-requires-customer.error';
+import { InsufficientPointsError } from '@modules/loyalty/domain/errors/insufficient-points.error';
+
+/**
+ * Fake of the two loyalty ports the orders context consumes, backed by an in-memory
+ * balance per customer. It applies the real redeem rate and ceiling rule (via the
+ * loyalty domain) and really debits points on redeemForOrder, so the order's total
+ * and the post-debit balance are exercised end-to-end - not asserted as mock calls.
+ * ensureAccount records the enrolled customer; failures are simulated with failNext.
+ */
+class FakeLoyalty implements LoyaltyRedemption, LoyaltyEnrollment {
+  private readonly balanceByCustomer = new Map<string, number>();
+  readonly enrolled: string[] = [];
+  private enrollmentError: Error | null = null;
+
+  seedBalance(customerId: string, points: number): void {
+    this.balanceByCustomer.set(customerId, points);
+  }
+
+  balanceOf(customerId: string): number | undefined {
+    return this.balanceByCustomer.get(customerId);
+  }
+
+  failEnrollmentOnce(error: Error): void {
+    this.enrollmentError = error;
+  }
+
+  quoteDiscount(input: QuoteDiscountInput): Promise<string> {
+    return Promise.resolve(this.resolveDiscount(input));
+  }
+
+  redeemForOrder(input: RedeemForOrderInput): Promise<string> {
+    const discount = this.resolveDiscount(input);
+    this.balanceByCustomer.set(
+      input.customerId,
+      (this.balanceByCustomer.get(input.customerId) ?? 0) - input.points,
+    );
+    return Promise.resolve(discount);
+  }
+
+  ensureAccount(customerId: string): Promise<void> {
+    if (this.enrollmentError) {
+      const error = this.enrollmentError;
+      this.enrollmentError = null;
+      return Promise.reject(error);
+    }
+    this.enrolled.push(customerId);
+    return Promise.resolve();
+  }
+
+  /** Mirrors RedeemPointsUseCase: consent/balance/ceiling guard then the deterministic rate. */
+  private resolveDiscount(input: QuoteDiscountInput): string {
+    const balance = this.balanceByCustomer.get(input.customerId) ?? 0;
+    if (!Number.isInteger(input.points) || input.points <= 0 || balance < input.points) {
+      throw new InsufficientPointsError(
+        `Customer ${input.customerId} cannot redeem ${input.points} points.`,
+      );
+    }
+    const discount = LoyaltyAccount.discountForPoints(input.points);
+    if (new Big(discount).gt(new Big(input.subtotal))) {
+      throw new InsufficientPointsError(
+        `Redeeming ${input.points} points exceeds the order subtotal R$${input.subtotal}.`,
+      );
+    }
+    return discount;
+  }
+}
 
 describe('CreateOrderUseCase', () => {
   const txContext: unknown = Symbol('tx-context');
@@ -34,7 +108,7 @@ describe('CreateOrderUseCase', () => {
   let resolveLookup: jest.MockedFunction<OrderProductLookup['resolve']>;
   let logAudit: jest.MockedFunction<AuditLogger['log']>;
   let deductForOrder: jest.MockedFunction<StockDeduction['deductForOrder']>;
-  let ensureAccount: jest.MockedFunction<LoyaltyEnrollment['ensureAccount']>;
+  let loyalty: FakeLoyalty;
 
   const command = (overrides: Partial<CreateOrderCommand> = {}): CreateOrderCommand => ({
     businessUnitId: 'bu-1',
@@ -75,8 +149,7 @@ describe('CreateOrderUseCase', () => {
     deductForOrder = jest.fn() as jest.MockedFunction<StockDeduction['deductForOrder']>;
     deductForOrder.mockResolvedValue({ lowStock: [] });
 
-    ensureAccount = jest.fn() as jest.MockedFunction<LoyaltyEnrollment['ensureAccount']>;
-    ensureAccount.mockResolvedValue(undefined);
+    loyalty = new FakeLoyalty();
 
     // Fake unit of work: runs the work immediately, handing it a sentinel tx
     // so tests can assert the same context reaches the repository.
@@ -104,10 +177,8 @@ describe('CreateOrderUseCase', () => {
           provide: STOCK_DEDUCTION,
           useValue: { deductForOrder } satisfies StockDeduction,
         },
-        {
-          provide: LOYALTY_ENROLLMENT,
-          useValue: { ensureAccount } satisfies LoyaltyEnrollment,
-        },
+        { provide: LOYALTY_ENROLLMENT, useValue: loyalty satisfies LoyaltyEnrollment },
+        { provide: LOYALTY_REDEMPTION, useValue: loyalty satisfies LoyaltyRedemption },
       ],
     }).compile();
 
@@ -345,7 +416,7 @@ describe('CreateOrderUseCase', () => {
 
       await useCase.execute(command(), { id: 'c-1', canAttend: false });
 
-      expect(ensureAccount).toHaveBeenCalledWith('c-1');
+      expect(loyalty.enrolled).toEqual(['c-1']);
     });
 
     it('skips enrollment when the order has no customer (anonymous channel)', async () => {
@@ -354,16 +425,68 @@ describe('CreateOrderUseCase', () => {
         canAttend: false,
       });
 
-      expect(ensureAccount).not.toHaveBeenCalled();
+      expect(loyalty.enrolled).toEqual([]);
     });
 
     it('a failing enrollment never breaks the created order (best-effort)', async () => {
       create.mockResolvedValue(persistedWithCustomer);
-      ensureAccount.mockRejectedValue(new Error('loyalty db down'));
+      loyalty.failEnrollmentOnce(new Error('loyalty db down'));
 
       const order = await useCase.execute(command(), { id: 'c-1', canAttend: false });
 
       expect(order).toBe(persistedWithCustomer);
+    });
+  });
+
+  describe('loyalty redemption', () => {
+    it('quotes the discount, persists the discounted total and debits points inside the tx', async () => {
+      // Subtotal is 2 * 10.00 = 20.00; 50 points price to a 5.00 discount, total 15.
+      loyalty.seedBalance('c-1', 80);
+
+      await useCase.execute(command({ pointsRedeemed: 50 }), { id: 'c-1', canAttend: false });
+
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({ totalAmount: '15', pointsRedeemed: 50 }),
+        txContext,
+      );
+      // The points were actually debited (80 - 50), proving redeemForOrder ran.
+      expect(loyalty.balanceOf('c-1')).toBe(30);
+    });
+
+    it('applies no discount and never touches the redemption port when no points are redeemed', async () => {
+      loyalty.seedBalance('c-1', 80);
+
+      await useCase.execute(command({ pointsRedeemed: 0 }), { id: 'c-1', canAttend: false });
+
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({ totalAmount: '20' }),
+        txContext,
+      );
+      // Untouched balance: no quote and no debit happened.
+      expect(loyalty.balanceOf('c-1')).toBe(80);
+    });
+
+    it('rejects with 422 and never opens the tx when points are redeemed without a customer', async () => {
+      await expect(
+        useCase.execute(command({ orderChannel: OrderChannel.TOTEM, pointsRedeemed: 50 }), {
+          id: 'u-1',
+          canAttend: false,
+        }),
+      ).rejects.toBeInstanceOf(PointsRedemptionRequiresCustomerError);
+
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('propagates an insufficient-balance error from the quote and never persists', async () => {
+      // 10 points on hand, asking for 50: the quote rejects before any insert.
+      loyalty.seedBalance('c-1', 10);
+
+      await expect(
+        useCase.execute(command({ pointsRedeemed: 50 }), { id: 'c-1', canAttend: false }),
+      ).rejects.toBeInstanceOf(InsufficientPointsError);
+
+      expect(create).not.toHaveBeenCalled();
+      expect(logAudit).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/orders/application/use-cases/create-order.use-case.ts
+++ b/src/modules/orders/application/use-cases/create-order.use-case.ts
@@ -33,6 +33,11 @@ import {
   LOYALTY_ENROLLMENT,
   type LoyaltyEnrollment,
 } from '@modules/loyalty/application/ports/loyalty-enrollment.port';
+import {
+  LOYALTY_REDEMPTION,
+  type LoyaltyRedemption,
+} from '@modules/loyalty/application/ports/loyalty-redemption.port';
+import { PointsRedemptionRequiresCustomerError } from '../errors/points-redemption-requires-customer.error';
 
 /** Who is performing the operation, resolved from the auth token by the HTTP layer. */
 export interface Actor {
@@ -76,6 +81,8 @@ export class CreateOrderUseCase {
     private readonly stock: StockDeduction,
     @Inject(LOYALTY_ENROLLMENT)
     private readonly enrollment: LoyaltyEnrollment,
+    @Inject(LOYALTY_REDEMPTION)
+    private readonly redemption: LoyaltyRedemption,
   ) {}
 
   async execute(command: CreateOrderCommand, actor: Actor): Promise<Order> {
@@ -89,6 +96,15 @@ export class CreateOrderUseCase {
 
     const { attendantId, customerId } = this.resolveParties(command, actor);
 
+    const redeems = (pointsRedeemed ?? 0) > 0;
+    // Points belong to a loyalty account: redeeming with no resolved customer has
+    // nobody to debit. Reject before opening the tx (422).
+    if (redeems && !customerId) {
+      throw new PointsRedemptionRequiresCustomerError(
+        'Cannot redeem loyalty points on an order without a customer.',
+      );
+    }
+
     // Validate and insert in one transaction, so the menu/product state can't change
     // between the read and the order insert.
     const { order, deduction } = await this.transactions.run(async (tx) => {
@@ -101,16 +117,29 @@ export class CreateOrderUseCase {
 
       const itemsSubtotal = Order.calculateItemsSubtotal(orderItems.map((item) => item.subtotal));
 
-      // TODO(loyalty): when the loyalty module ships, derive this discount from
-      // pointsRedeemed (points -> money at the loyalty rate) instead of 0. The discount
-      // rule (total = subtotal - discount) already lives in Order.computeTotal.
-      const discountAmount = new Big(0);
+      // The redeem discount needs the orderId for its REDEEM transaction row, but the
+      // id is DB-generated at create. So we quote the discount first (read-only, sets
+      // the authoritative total), create the order, then debit the points keyed to that
+      // id - all inside this tx, so any later failure (stock) rolls the debit back with
+      // the order. Loyalty rules and the rate stay behind the port; orders never reads
+      // the loyalty domain. The discount is deterministic, so quote and debit agree.
+      const discountAmount = redeems
+        ? new Big(
+            await this.redemption.quoteDiscount(
+              {
+                customerId: customerId as string,
+                points: pointsRedeemed as number,
+                subtotal: itemsSubtotal.toFixed(2),
+              },
+              tx,
+            ),
+          )
+        : new Big(0);
       const totalAmount = Order.computeTotal(itemsSubtotal, discountAmount).toString();
 
-      // TODO(loyalty): pointsEarned stays at the DB default (0) on creation. Points
-      // (1 per R$10 of the paid amount, gated by LoyaltyAccount consent) are credited
-      // by the loyalty module when the payment is approved; LoyaltyTransaction is the
-      // source of truth.
+      // pointsEarned stays at the DB default (0) on creation. Points (1 per R$10 of the
+      // paid amount, gated by LoyaltyAccount consent) are credited by the loyalty module
+      // when the payment is approved; LoyaltyTransaction is the source of truth.
 
       const created = await this.orders.create(
         {
@@ -125,6 +154,23 @@ export class CreateOrderUseCase {
         },
         tx,
       );
+
+      if (redeems) {
+        // Debit the points in the same tx. Insufficient balance (INVALID) or a
+        // concurrent debit (CONFLICT) propagates and rolls back the order - redemption
+        // is not best-effort. customerId is non-null here (guarded above).
+        // TODO(loyalty-refund): when order cancellation/refund ships, credit the
+        // redeemed points back with a compensating transaction.
+        await this.redemption.redeemForOrder(
+          {
+            customerId: customerId as string,
+            orderId: created.id,
+            points: pointsRedeemed as number,
+            subtotal: itemsSubtotal.toFixed(2),
+          },
+          tx,
+        );
+      }
 
       // Stock goes out in the same transaction: any item without enough stock
       // throws and rolls back the order plus every deduction already applied.


### PR DESCRIPTION
- redeem points as an order discount, debiting balance in the same transaction that creates the order; fixed rate 1 point = R$0.10, redemption only at order creation
- add LOYALTY_REDEMPTION port with two steps (quoteDiscount + redeemForOrder) run in the same tx since orderId is db-generated
- RedeemPointsUseCase validates consent, balance and cap (discount must not exceed subtotal, otherwise 422)
- optimistic concurrency via conditional UPDATE (totalPoints >= points); the loser maps to CONFLICT 409
- idempotency via @@unique(orderId, type) with P2002 handling
- reject order without customerId when pointsRedeemed > 0 (422)
- record REDEEM LoyaltyTransaction (positive points + totalPoints decrement, mirroring EARN)
- CreateOrderUseCase now derives the real discount/total, removing the hardcoded discount = Big(0)