### PR TITLE
feat(observability): add request access logging and API rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,14 @@ JWT_SECRET_KEY=
 
 # Shared secret the payment gateway webhook must send in the "x-webhook-secret" header.
 PAYMENT_WEBHOOK_SECRET=
+
+# Trust proxy: "true"/"false" or a number of trusted hops. Leave unset (off) in
+# dev. Enable ONLY behind a trusted reverse proxy, otherwise X-Forwarded-For can
+# be spoofed.
+# TRUST_PROXY=
+
+# Rate limit window in milliseconds. Default 60000.
+THROTTLE_TTL_MS=60000
+
+# Max requests per window per IP. Default 100.
+THROTTLE_LIMIT=100

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.4.3",
+        "@nestjs/throttler": "^6.5.0",
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
         "argon2": "^0.44.0",
@@ -3595,6 +3596,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.4.3",
+    "@nestjs/throttler": "^6.5.0",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "argon2": "^0.44.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module, ValidationPipe } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule, ValidationPipe } from '@nestjs/common';
 import { PrismaModule } from '@shared/infrastructure/prisma/prisma.module';
 import { BusinessUnitsModule } from '@modules/business-units/business-units.module';
 import { ConfigModule } from '@nestjs/config';
@@ -11,10 +11,30 @@ import { OrdersModule } from '@modules/orders/orders.module';
 import { PaymentsModule } from '@modules/payments/payments.module';
 import { InventoryModule } from '@modules/inventory/inventory.module';
 import { LoyaltyModule } from '@modules/loyalty/loyalty.module';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { RequestLoggingMiddleware } from '@shared/observability/request-logging.middleware';
+import { parseIntEnv } from '@shared/config/env';
+
+// Global rate limit defaults to 100 req / 60s per IP. Both values are read from
+// env so tighter limits can be set in e2e without standing up a real clock.
+// Read at module load (not inside forRoot) so the throttling e2e can set
+// THROTTLE_LIMIT before requiring this module. A present but invalid value fails
+// the boot instead of silently falling back to the default.
+const THROTTLE_TTL_MS = parseIntEnv('THROTTLE_TTL_MS', process.env.THROTTLE_TTL_MS, 60000, {
+  min: 1,
+});
+const THROTTLE_LIMIT = parseIntEnv('THROTTLE_LIMIT', process.env.THROTTLE_LIMIT, 100, { min: 1 });
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    // Uses the default in-memory storage. In a multi-instance deployment each
+    // replica keeps its own counter, so the effective limit becomes limit*N and
+    // the login brute-force protection weakens. Swap for
+    // @nest-lab/throttler-storage-redis when scaling horizontally.
+    ThrottlerModule.forRoot({
+      throttlers: [{ ttl: THROTTLE_TTL_MS, limit: THROTTLE_LIMIT }],
+    }),
     PrismaModule,
     AuditModule,
     IdentityModule,
@@ -25,6 +45,12 @@ import { LoyaltyModule } from '@modules/loyalty/loyalty.module';
     PaymentsModule,
   ],
   providers: [
+    // ThrottlerGuard runs before AuthGuard so even @Public() routes (login) are
+    // rate limited. APP_GUARD order follows the providers array order.
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
@@ -44,4 +70,8 @@ import { LoyaltyModule } from '@modules/loyalty/loyalty.module';
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(RequestLoggingMiddleware).forRoutes('{*splat}');
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,11 @@ import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { AppModule } from './app.module';
+import { parseTrustProxy } from '@shared/config/env';
 
 function readAppVersion(): string {
   const raw: unknown = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
@@ -21,11 +23,21 @@ function readAppVersion(): string {
 
 async function bootstrap(): Promise<void> {
   const logger = new Logger('Bootstrap');
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   app.setGlobalPrefix('api');
   app.enableCors(); // TODO: Configure CORS properly for production
   app.enableShutdownHooks();
+
+  // Trust proxy is off by default. Enable it ONLY when a trusted reverse proxy
+  // sits in front of us, otherwise a client can spoof X-Forwarded-For and forge
+  // its IP, which would poison the access log and the rate limiter tracker.
+  // TRUST_PROXY accepts 'true'/'false' or a number of trusted hops. A present
+  // but invalid value throws here and crashes the boot instead of silently
+  // leaving the proxy untrusted.
+  if (process.env.TRUST_PROXY !== undefined) {
+    app.set('trust proxy', parseTrustProxy(process.env.TRUST_PROXY));
+  }
 
   const port = Number(process.env.PORT) || 3000;
 

--- a/src/modules/identity/infrastructure/http/controllers/auth.controller.ts
+++ b/src/modules/identity/infrastructure/http/controllers/auth.controller.ts
@@ -2,11 +2,14 @@ import { SignInUseCase } from '@modules/identity/application/use-cases/sign-in.u
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { SignInDto } from '../dto/sign-in-request.dto';
 import { Public } from '@shared/auth/public.decorator';
+import { Throttle } from '@nestjs/throttler';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly signInUseCase: SignInUseCase) {}
 
+  // Stricter limit than the global one to slow credential brute-force.
+  @Throttle({ default: { ttl: 60000, limit: 5 } })
   @Public()
   @HttpCode(HttpStatus.OK)
   @Post('login')

--- a/src/modules/payments/infrastructure/http/controllers/payments.controller.ts
+++ b/src/modules/payments/infrastructure/http/controllers/payments.controller.ts
@@ -30,6 +30,7 @@ import { PaymentWebhookAckDto } from '../dto/payment-webhook-ack.dto';
 import { OrderPaymentParamDto } from '../dto/payment-params.dto';
 import { PaymentResponseDto } from '../dto/payment-response.dto';
 import { PaymentWebhookGuard } from '../guards/payment-webhook.guard';
+import { SkipThrottle } from '@nestjs/throttler';
 
 @ApiTags('payments')
 @Controller()
@@ -58,6 +59,9 @@ export class PaymentsController {
     return PaymentResponseDto.fromEntity(payment);
   }
 
+  // Gateway callbacks are authenticated by HMAC and can legitimately burst on
+  // retries, so they are exempt from the rate limiter.
+  @SkipThrottle()
   @Post('payments/webhook')
   @Public()
   @UseGuards(PaymentWebhookGuard)

--- a/src/shared/config/env.spec.ts
+++ b/src/shared/config/env.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from '@jest/globals';
+import { parseIntEnv, parseTrustProxy } from './env';
+
+describe('parseIntEnv', () => {
+  it('returns the default when the var is absent', () => {
+    expect(parseIntEnv('X', undefined, 100)).toBe(100);
+  });
+
+  it('treats empty string as absent and returns the default', () => {
+    expect(parseIntEnv('X', '', 100)).toBe(100);
+  });
+
+  it('parses a valid integer', () => {
+    expect(parseIntEnv('X', '50', 100)).toBe(50);
+  });
+
+  it('throws on a non integer value', () => {
+    expect(() => parseIntEnv('X', 'abc', 100)).toThrow(/X/);
+  });
+
+  it('throws on a non integer numeric value', () => {
+    expect(() => parseIntEnv('X', '1.5', 100)).toThrow(/X/);
+  });
+
+  it('throws when below min', () => {
+    expect(() => parseIntEnv('THROTTLE_LIMIT', '0', 100, { min: 1 })).toThrow(/THROTTLE_LIMIT/);
+  });
+
+  it('accepts a value at the min boundary', () => {
+    expect(parseIntEnv('THROTTLE_LIMIT', '1', 100, { min: 1 })).toBe(1);
+  });
+});
+
+describe('parseTrustProxy', () => {
+  it('returns false when absent', () => {
+    expect(parseTrustProxy(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(parseTrustProxy('')).toBe(false);
+  });
+
+  it('returns true for "true"', () => {
+    expect(parseTrustProxy('true')).toBe(true);
+  });
+
+  it('returns false for "false"', () => {
+    expect(parseTrustProxy('false')).toBe(false);
+  });
+
+  it('returns the hop count for an integer', () => {
+    expect(parseTrustProxy('2')).toBe(2);
+  });
+
+  it('throws on an unrecognized value', () => {
+    expect(() => parseTrustProxy('foo')).toThrow(/TRUST_PROXY/);
+  });
+
+  it('throws on a negative hop count', () => {
+    expect(() => parseTrustProxy('-1')).toThrow(/TRUST_PROXY/);
+  });
+});

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -1,0 +1,54 @@
+// Boot-time env parsing. These run while the process is starting, before the
+// Nest exception filter exists, so they throw plain Error and let the boot
+// crash. The point is fail-fast: an absent var falls back to its default, but a
+// present-but-invalid var must stop the boot instead of silently degrading.
+
+// Parse an integer env var. Treats undefined and '' as absent (returns the
+// default). A present value that is not a valid integer, or that violates the
+// optional min, throws and names both the var and the received value.
+export function parseIntEnv(
+  name: string,
+  raw: string | undefined,
+  defaultValue: number,
+  opts: { min?: number } = {},
+): number {
+  // Number('') is 0, so empty string must be treated as absent before parsing.
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`Invalid env ${name}: expected an integer, received "${raw}"`);
+  }
+
+  if (opts.min !== undefined && parsed < opts.min) {
+    throw new Error(`Invalid env ${name}: expected an integer >= ${opts.min}, received "${raw}"`);
+  }
+
+  return parsed;
+}
+
+// Map TRUST_PROXY into what express understands: a boolean for the on/off cases
+// or a hop count when a non negative integer is given. Absent means off. A
+// present but unrecognized value throws instead of silently falling back to off.
+export function parseTrustProxy(raw: string | undefined): boolean | number {
+  if (raw === undefined || raw === '') {
+    return false;
+  }
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
+    return false;
+  }
+
+  const hops = Number(raw);
+  if (Number.isInteger(hops) && hops >= 0) {
+    return hops;
+  }
+
+  throw new Error(
+    `Invalid env TRUST_PROXY: expected "true", "false" or an integer >= 0, received "${raw}"`,
+  );
+}

--- a/src/shared/observability/client-detection.spec.ts
+++ b/src/shared/observability/client-detection.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals';
+import { detectClient } from './client-detection';
+
+describe('detectClient', () => {
+  it('detects Postman from PostmanRuntime', () => {
+    const result = detectClient('PostmanRuntime/7.39.0');
+    expect(result.client).toBe('postman');
+    expect(result.raw).toBe('PostmanRuntime/7.39.0');
+  });
+
+  it('detects curl', () => {
+    expect(detectClient('curl/8.7.1').client).toBe('curl');
+  });
+
+  it('detects insomnia', () => {
+    expect(detectClient('insomnia/9.3.2').client).toBe('insomnia');
+  });
+
+  it('detects a desktop browser', () => {
+    const chrome =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+    expect(detectClient(chrome).client).toBe('browser');
+  });
+
+  it('returns unknown for an empty string', () => {
+    const result = detectClient('');
+    expect(result.client).toBe('unknown');
+    expect(result.raw).toBe('');
+  });
+
+  it('returns unknown for undefined', () => {
+    const result = detectClient(undefined);
+    expect(result.client).toBe('unknown');
+    expect(result.raw).toBe('');
+  });
+
+  it('returns unknown for an unrecognized agent', () => {
+    expect(detectClient('SomeRandomBot/1.0').client).toBe('unknown');
+  });
+});

--- a/src/shared/observability/client-detection.ts
+++ b/src/shared/observability/client-detection.ts
@@ -1,0 +1,32 @@
+// User-Agent is client controlled and trivially spoofable. This detection is
+// for observability only (knowing roughly who is calling us in the access log).
+// Never use the result for authorization or any security decision.
+
+export type ClientKind = 'postman' | 'curl' | 'insomnia' | 'browser' | 'unknown';
+
+const POSTMAN = /PostmanRuntime/i;
+const CURL = /curl/i;
+const INSOMNIA = /insomnia/i;
+const BROWSER = /Mozilla|Chrome|Safari|Firefox|Edge/i;
+
+export function detectClient(userAgent: string | undefined): { client: ClientKind; raw: string } {
+  const raw = userAgent ?? '';
+
+  if (raw.length === 0) {
+    return { client: 'unknown', raw };
+  }
+  if (POSTMAN.test(raw)) {
+    return { client: 'postman', raw };
+  }
+  if (CURL.test(raw)) {
+    return { client: 'curl', raw };
+  }
+  if (INSOMNIA.test(raw)) {
+    return { client: 'insomnia', raw };
+  }
+  if (BROWSER.test(raw)) {
+    return { client: 'browser', raw };
+  }
+
+  return { client: 'unknown', raw };
+}

--- a/src/shared/observability/request-logging.middleware.spec.ts
+++ b/src/shared/observability/request-logging.middleware.spec.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import { RequestLoggingMiddleware } from './request-logging.middleware';
+
+// Minimal fake Response that captures the 'finish' listener so the test can
+// fire it on demand, the way express would once the response is sent.
+function createFakeResponse(statusCode: number): {
+  res: Response;
+  fireFinish: () => void;
+} {
+  let finishCb: (() => void) | undefined;
+  const on = (event: string, cb: () => void): void => {
+    if (event === 'finish') {
+      finishCb = cb;
+    }
+  };
+  const res = { statusCode, on } as unknown as Response;
+
+  return {
+    res,
+    fireFinish: (): void => {
+      if (finishCb) {
+        finishCb();
+      }
+    },
+  };
+}
+
+function createFakeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'GET',
+    originalUrl: '/api/products',
+    url: '/api/products',
+    ip: '203.0.113.7',
+    headers: { 'user-agent': 'PostmanRuntime/7.39.0' },
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe('RequestLoggingMiddleware', () => {
+  let middleware: RequestLoggingMiddleware;
+  let logSpy: jest.SpiedFunction<typeof Logger.prototype.log>;
+  let warnSpy: jest.SpiedFunction<typeof Logger.prototype.warn>;
+  let errorSpy: jest.SpiedFunction<typeof Logger.prototype.error>;
+
+  beforeEach(() => {
+    middleware = new RequestLoggingMiddleware();
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls next immediately and logs only on finish', () => {
+    const req = createFakeRequest();
+    const { res, fireFinish } = createFakeResponse(200);
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(logSpy).not.toHaveBeenCalled();
+
+    fireFinish();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs transport metadata including userId from req.user', () => {
+    const req = createFakeRequest({
+      user: { sub: 'user-123', username: 'jane', role: 'ADMIN', iat: 0, exp: 0 },
+    } as Partial<Request>);
+    const { res, fireFinish } = createFakeResponse(200);
+
+    middleware.use(req, res, jest.fn());
+    fireFinish();
+
+    const entry = logSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(entry).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        path: '/api/products',
+        statusCode: 200,
+        ip: '203.0.113.7',
+        client: 'postman',
+        userAgent: 'PostmanRuntime/7.39.0',
+        userId: 'user-123',
+      }),
+    );
+    expect(entry).toHaveProperty('durationMs');
+  });
+
+  it('does not log the authorization header', () => {
+    const req = createFakeRequest({
+      headers: { 'user-agent': 'curl/8.7.1', authorization: 'Bearer secret-token' },
+    } as Partial<Request>);
+    const { res, fireFinish } = createFakeResponse(200);
+
+    middleware.use(req, res, jest.fn());
+    fireFinish();
+
+    const serialized = JSON.stringify(logSpy.mock.calls[0][0]);
+    expect(serialized).not.toContain('secret-token');
+    expect(serialized).not.toContain('authorization');
+  });
+
+  it('logs only the pathname and never the query string', () => {
+    const req = createFakeRequest({
+      originalUrl: '/api/x?token=secret123',
+      url: '/api/x?token=secret123',
+    } as Partial<Request>);
+    const { res, fireFinish } = createFakeResponse(200);
+
+    middleware.use(req, res, jest.fn());
+    fireFinish();
+
+    const entry = logSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(entry.path).toBe('/api/x');
+
+    const serialized = JSON.stringify(logSpy.mock.calls[0][0]);
+    expect(serialized).not.toContain('secret123');
+  });
+
+  it('uses warn level for 4xx', () => {
+    const req = createFakeRequest();
+    const { res, fireFinish } = createFakeResponse(404);
+
+    middleware.use(req, res, jest.fn());
+    fireFinish();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses error level for 5xx', () => {
+    const req = createFakeRequest();
+    const { res, fireFinish } = createFakeResponse(500);
+
+    middleware.use(req, res, jest.fn());
+    fireFinish();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/observability/request-logging.middleware.ts
+++ b/src/shared/observability/request-logging.middleware.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import { detectClient } from './client-detection';
+
+// Access log. We log on res 'finish' instead of right after next() because by
+// then the guards have run (so req.user is populated) and the status code and
+// total duration are known. We only record transport metadata. Never log the
+// Authorization header, request body, passwords, cpf or tokens.
+@Injectable()
+export class RequestLoggingMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(RequestLoggingMiddleware.name);
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    const startNs = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const durationMs = Number(process.hrtime.bigint() - startNs) / 1_000_000;
+      const { client, raw } = detectClient(req.headers['user-agent']);
+
+      // Strip the query string and log only the pathname. The query can carry
+      // tokens, cpf or email and the access log must never persist those.
+      const path = (req.originalUrl ?? req.url ?? '').split('?')[0];
+
+      const entry = {
+        method: req.method,
+        path,
+        statusCode: res.statusCode,
+        durationMs: Math.round(durationMs * 100) / 100,
+        ip: req.ip,
+        client,
+        userAgent: raw,
+        userId: req.user?.sub,
+      };
+
+      if (res.statusCode >= 500) {
+        this.logger.error(entry);
+      } else if (res.statusCode >= 400) {
+        this.logger.warn(entry);
+      } else {
+        this.logger.log(entry);
+      }
+    });
+
+    next();
+  }
+}

--- a/test/throttling.e2e-spec.ts
+++ b/test/throttling.e2e-spec.ts
@@ -1,0 +1,46 @@
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import type { Server } from 'http';
+import request from 'supertest';
+
+// The global throttler reads its ttl/limit from env. We set a tiny limit here
+// BEFORE importing AppModule so the test does not depend on the real 100/60s
+// budget and stays fast and deterministic. ttl stays large enough that the
+// window does not roll over mid-test.
+const THROTTLE_LIMIT = 3;
+process.env.THROTTLE_LIMIT = String(THROTTLE_LIMIT);
+process.env.THROTTLE_TTL_MS = '60000';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AppModule } = require('../src/app.module') as typeof import('../src/app.module');
+
+describe('Throttling (e2e)', () => {
+  let app: INestApplication;
+  let server: Server;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    server = app.getHttpServer() as Server;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 429 once a public route exceeds the per-IP limit', async () => {
+    // The first THROTTLE_LIMIT requests pass, the next one is rejected.
+    for (let i = 0; i < THROTTLE_LIMIT; i++) {
+      await request(server).get('/api/products').expect(200);
+    }
+
+    await request(server).get('/api/products').expect(429);
+  });
+});


### PR DESCRIPTION
- log each request on response finish: method, pathname (no query string to avoid leaking token/cpf), status, duration, ip, user-agent, derived client and userId
- detectClient: pure heuristic for observability only, never authz
- gate trust proxy behind TRUST_PROXY env (off by default, fail-fast on invalid value) to keep X-Forwarded-For trustworthy
- parseIntEnv helper: fail-fast numeric env parsing (no swallowing of 0/NaN/empty)
- rate limit via @nestjs/throttler: global 100/60s (ttl/limit from env), ThrottlerGuard before AuthGuard so public routes are covered
- login throttled 5/60s against brute-force; payment webhook SkipThrottle (already protected by HMAC)