### PR TITLE
feat(shared): add immutable Money value object wrapping big.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ likewise validated as decimal strings (`@IsDecimal`) and never coerced via
 
 **7. `shared/` is the cross-context kernel**
 Anything reused across two or more contexts (Prisma client lifecycle,
-pagination primitives, future `Money`/`Email` value objects, global guards
+pagination primitives, the `Money` value object (and future `Email`/`Id` VOs), global guards
 and interceptors) lives in `src/shared/`. If something is used by only one
 context, it stays inside that context.
 

--- a/src/shared/domain/value-objects/money.spec.ts
+++ b/src/shared/domain/value-objects/money.spec.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from '@jest/globals';
+import { InvalidMoneyError } from '@shared/errors/domain/invalid-money.error';
+import { Money } from './money';
+
+describe('Money', () => {
+  describe('creation', () => {
+    it('builds from a valid decimal string', () => {
+      expect(Money.fromDecimalString('10.50').toDecimalString()).toBe('10.50');
+    });
+
+    it('zero() is 0.00', () => {
+      expect(Money.zero().toDecimalString()).toBe('0.00');
+    });
+
+    it('builds from integer cents', () => {
+      expect(Money.fromCents(1050).toDecimalString()).toBe('10.50');
+    });
+  });
+
+  describe('invalid creation', () => {
+    it.each(['abc', '', 'NaN'])('throws InvalidMoneyError for "%s"', (input) => {
+      expect(() => Money.fromDecimalString(input)).toThrow(InvalidMoneyError);
+    });
+
+    it('preserves the original big.js error as cause', () => {
+      expect.assertions(2);
+      try {
+        Money.fromDecimalString('abc');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidMoneyError);
+        expect((err as InvalidMoneyError).cause).toBeInstanceOf(Error);
+      }
+    });
+
+    it.each([10.5, NaN, Infinity, -Infinity])(
+      'throws InvalidMoneyError for non-integer cents %p',
+      (cents) => {
+        expect(() => Money.fromCents(cents)).toThrow(InvalidMoneyError);
+      },
+    );
+  });
+
+  describe('equality', () => {
+    it('treats 10.00 and 10 as equal', () => {
+      expect(Money.fromDecimalString('10.00').equals(Money.fromDecimalString('10'))).toBe(true);
+    });
+
+    it('treats 10.00 and 10.01 as different', () => {
+      expect(Money.fromDecimalString('10.00').equals(Money.fromDecimalString('10.01'))).toBe(false);
+    });
+  });
+
+  describe('arithmetic', () => {
+    it('adds', () => {
+      expect(
+        Money.fromDecimalString('10.50').plus(Money.fromDecimalString('0.25')).toDecimalString(),
+      ).toBe('10.75');
+    });
+
+    it('subtracts', () => {
+      expect(
+        Money.fromDecimalString('10').minus(Money.fromDecimalString('3.50')).toDecimalString(),
+      ).toBe('6.50');
+    });
+
+    it('multiplies by a number scalar', () => {
+      expect(Money.fromDecimalString('10').times(3).toDecimalString()).toBe('30.00');
+    });
+
+    it('multiplies by a string scalar', () => {
+      expect(Money.fromDecimalString('10.10').times('2').toDecimalString()).toBe('20.20');
+    });
+
+    it('keeps operands immutable', () => {
+      const a = Money.fromDecimalString('10.50');
+      const b = Money.fromDecimalString('0.25');
+      a.plus(b);
+      expect(a.toDecimalString()).toBe('10.50');
+      expect(b.toDecimalString()).toBe('0.25');
+    });
+  });
+
+  describe('rounding on output', () => {
+    it('rounds half-up to 2 places only at the border', () => {
+      // 10 * 0.333 = 3.33 (full precision kept, rounded only here)
+      expect(Money.fromDecimalString('10').times('0.333').toDecimalString()).toBe('3.33');
+    });
+
+    it('rounds half-up away from zero on negatives', () => {
+      // big.js roundHalfUp rounds away from zero on ties, so -3.335 -> -3.34.
+      expect(Money.fromDecimalString('-3.335').toDecimalString()).toBe('-3.34');
+    });
+
+    it('keeps internal precision across chained ops', () => {
+      // 10 * 0.333 = 3.33 exactly, + 0.005 = 3.335 (not truncated mid-chain),
+      // which only rounds up to 3.34 if the 0.005 survived; proves no early cut.
+      const result = Money.fromDecimalString('10')
+        .times('0.333')
+        .plus(Money.fromDecimalString('0.005'));
+      expect(result.toDecimalString()).toBe('3.34');
+    });
+  });
+
+  describe('zero', () => {
+    it('zero() isZero', () => {
+      expect(Money.zero().isZero()).toBe(true);
+    });
+
+    it('0.00 isZero', () => {
+      expect(Money.fromDecimalString('0.00').isZero()).toBe(true);
+    });
+  });
+
+  describe('negatives', () => {
+    it('5 - 8 is negative', () => {
+      const result = Money.fromDecimalString('5').minus(Money.fromDecimalString('8'));
+      expect(result.isNegative()).toBe(true);
+      expect(result.toDecimalString()).toBe('-3.00');
+    });
+  });
+
+  describe('comparisons', () => {
+    const five = Money.fromDecimalString('5');
+    const ten = Money.fromDecimalString('10');
+    const alsoTen = Money.fromDecimalString('10.00');
+
+    it('greaterThan', () => {
+      expect(ten.greaterThan(five)).toBe(true);
+      expect(five.greaterThan(ten)).toBe(false);
+      expect(ten.greaterThan(alsoTen)).toBe(false);
+    });
+
+    it('lessThan', () => {
+      expect(five.lessThan(ten)).toBe(true);
+      expect(ten.lessThan(five)).toBe(false);
+      expect(ten.lessThan(alsoTen)).toBe(false);
+    });
+
+    it('greaterThanOrEqual', () => {
+      expect(ten.greaterThanOrEqual(alsoTen)).toBe(true);
+      expect(ten.greaterThanOrEqual(five)).toBe(true);
+      expect(five.greaterThanOrEqual(ten)).toBe(false);
+    });
+
+    it('lessThanOrEqual', () => {
+      expect(ten.lessThanOrEqual(alsoTen)).toBe(true);
+      expect(five.lessThanOrEqual(ten)).toBe(true);
+      expect(ten.lessThanOrEqual(five)).toBe(false);
+    });
+
+    it('isPositive', () => {
+      expect(five.isPositive()).toBe(true);
+      expect(Money.zero().isPositive()).toBe(false);
+    });
+  });
+
+  describe('serialization', () => {
+    it('JSON.stringify uses the decimal string', () => {
+      expect(JSON.stringify({ price: Money.fromDecimalString('12.5') })).toBe('{"price":"12.50"}');
+    });
+  });
+
+  describe('toCents', () => {
+    it('returns the integer cents', () => {
+      expect(Money.fromDecimalString('10.50').toCents()).toBe(1050);
+    });
+
+    it('rounds half-up to integer cents', () => {
+      // 10.505 -> 1050.5 -> 1051 (away from zero on the tie).
+      expect(Money.fromDecimalString('10.505').toCents()).toBe(1051);
+    });
+
+    it('keeps the sign on negatives', () => {
+      expect(Money.fromDecimalString('-10.50').toCents()).toBe(-1050);
+    });
+
+    it('throws when cents overflow MAX_SAFE_INTEGER', () => {
+      // 99999999999999999 * 100 cents is far above Number.MAX_SAFE_INTEGER,
+      // where number can no longer represent every integer exactly.
+      expect(() => Money.fromDecimalString('99999999999999999').toCents()).toThrow(
+        InvalidMoneyError,
+      );
+    });
+  });
+});

--- a/src/shared/domain/value-objects/money.ts
+++ b/src/shared/domain/value-objects/money.ts
@@ -1,0 +1,119 @@
+import Big from 'big.js';
+import { InvalidMoneyError } from '@shared/errors/domain/invalid-money.error';
+
+/**
+ * Immutable monetary value object wrapping big.js. The internal Big is never
+ * exposed so callers cannot bypass the VO and do raw arithmetic. Full precision
+ * is kept across operations; rounding happens only at the output borders
+ * (toDecimalString, toCents). Construct via the static factories, not new.
+ *
+ * Money is signed: negatives are allowed on purpose, for deltas, refunds and
+ * discounts. The non-negativity rule belongs to the entities that own the
+ * amount, not to this VO.
+ */
+export class Money {
+  private readonly value: Big;
+
+  private constructor(value: Big) {
+    this.value = value;
+  }
+
+  /**
+   * Entry border for decimal strings, typically Prisma Decimal.toString(). big.js
+   * throws on NaN, empty or malformed input, so we wrap it and rethrow a domain
+   * error keeping the original cause.
+   */
+  static fromDecimalString(amount: string): Money {
+    try {
+      return new Money(new Big(amount));
+    } catch (err) {
+      throw new InvalidMoneyError(`Invalid monetary amount: "${amount}".`, {
+        cause: err,
+      });
+    }
+  }
+
+  static zero(): Money {
+    return new Money(new Big(0));
+  }
+
+  /**
+   * Builds from an integer number of cents (e.g. 1050 -> 10.50). Rejects non
+   * integer or non finite inputs since cents are indivisible here.
+   */
+  static fromCents(cents: number): Money {
+    if (!Number.isInteger(cents)) {
+      throw new InvalidMoneyError(`Cents must be a finite integer, received: ${cents}.`);
+    }
+    return new Money(new Big(cents).div(100));
+  }
+
+  plus(other: Money): Money {
+    return new Money(this.value.plus(other.value));
+  }
+
+  minus(other: Money): Money {
+    return new Money(this.value.minus(other.value));
+  }
+
+  // Scalar multiply (a quantity or rate), not another Money.
+  times(factor: number | string): Money {
+    return new Money(this.value.times(factor));
+  }
+
+  equals(other: Money): boolean {
+    return this.value.eq(other.value);
+  }
+
+  greaterThan(other: Money): boolean {
+    return this.value.gt(other.value);
+  }
+
+  lessThan(other: Money): boolean {
+    return this.value.lt(other.value);
+  }
+
+  greaterThanOrEqual(other: Money): boolean {
+    return this.value.gte(other.value);
+  }
+
+  lessThanOrEqual(other: Money): boolean {
+    return this.value.lte(other.value);
+  }
+
+  isZero(): boolean {
+    return this.value.eq(0);
+  }
+
+  isNegative(): boolean {
+    return this.value.lt(0);
+  }
+
+  isPositive(): boolean {
+    return this.value.gt(0);
+  }
+
+  /**
+   * Output border: 2 decimal places, half-up. The rounding mode is passed
+   * explicitly so we never depend on the global Big.RM nor mutate it.
+   */
+  toDecimalString(): string {
+    return this.value.toFixed(2, Big.roundHalfUp);
+  }
+
+  toCents(): number {
+    // number loses precision above MAX_SAFE_INTEGER, so guard before returning.
+    const cents = Number(this.value.times(100).round(0, Big.roundHalfUp).toString());
+    if (!Number.isSafeInteger(cents)) {
+      throw new InvalidMoneyError(
+        `Monetary amount too large to represent as integer cents: ${this.toDecimalString()}.`,
+      );
+    }
+    return cents;
+  }
+
+  // Lets JSON.stringify serialize Money as its decimal string automatically.
+  toJSON(): string {
+    return this.toDecimalString();
+  }
+}

--- a/src/shared/errors/domain/invalid-money.error.ts
+++ b/src/shared/errors/domain/invalid-money.error.ts
@@ -1,0 +1,13 @@
+import { DomainError } from '@shared/errors/domain/domain.error';
+import { ERROR_KINDS } from '@shared/errors/errors.type';
+
+/**
+ * A monetary amount could not be built or is malformed: a value that big.js
+ * rejects (NaN, empty or non-numeric string), or a cents input that is not a
+ * finite integer. Guards the entry borders of the Money VO.
+ */
+export class InvalidMoneyError extends DomainError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(ERROR_KINDS.INVALID, message, options);
+  }
+}


### PR DESCRIPTION
- encapsulate big.js in an immutable Money VO; internal Big is private, never exposed (no getter), closing the door to external mutation
- factories fromDecimalString (Prisma boundary), zero, fromCents; no fromNumber so float input is impossible by construction
- immutable arithmetic plus/minus/times(scalar) and comparisons equals/greaterThan/lessThan/gte/lte/isZero/isNegative/isPositive
- half-up rounding only at the output edge (toDecimalString/toCents/ toJSON) with explicit rounding mode; never mutate global Big.RM
- toCents guards with Number.isSafeInteger and throws InvalidMoneyError on overflow
- Money is signed; non-negativity stays an entity-level rule
- add InvalidMoneyError (DomainError, kind=invalid) for malformed input, with chained cause
- unit tests for the VO, no mocks; existing entities left unrefactored (next scope)
- docs: README no longer lists Money as a future VO