### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Raízes do Nordeste - Backend API
 
 [![CI](https://github.com/M4rcosz/raizes-do-nordeste/actions/workflows/ci.yml/badge.svg)](https://github.com/M4rcosz/raizes-do-nordeste/actions/workflows/ci.yml)
+[![version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/M4rcosz/raizes-do-nordeste/releases/tag/v1.0.0)
+
+Repository: <https://github.com/M4rcosz/raizes-do-nordeste>
 
 REST API for a multi-unit restaurant ordering system. The platform powers menu
 browsing, order management, payment processing, inventory control and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raizes-do-nordeste",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raizes-do-nordeste",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raizes-do-nordeste",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Multi-unit restaurant management API for Raízes do Nordeste",
   "author": "Marcos Paulo Freire Almeida",
   "private": true,


### PR DESCRIPTION
## Release v1.0.0

First stable release. All seven product bounded contexts (+ audit) ship application code: identity, business-units, inventory, orders, payments, promotions, loyalty.

### Changes in this PR
- Bump version to `1.0.0` (`package.json` + `package-lock.json`)
- Add a version badge and the repository link to the README

### Release steps after merge
- Tag `v1.0.0` will be created on `main` and pushed (the README badge already links to `/releases/tag/v1.0.0`).
